### PR TITLE
docs: Phase 2 — concepts, why, faq, architecture, roadmap, php walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,17 +175,23 @@ Pages are short, scoped, and self-contained — pick the one that matches what y
 
 | | |
 |---|---|
+| **[Concepts](./docs/concepts.md)** | The mental model in one page: types, entries, ids vs slugs vs refs, versions, structural vs inline references, assets, locales, environments, the wire format. Read this first. |
 | **[Build with an agent](./docs/build-with-an-agent.md)** | End-to-end walkthrough: ask Claude to set up the schema, seed content, build an Astro site that renders it, wire up inline editing. Anchored to the committed `examples/astro-blog/` artifact. |
+| **[Build with an agent — PHP](./docs/build-with-an-agent-php.md)** | Same walkthrough, vanilla PHP consumer using `Ledric\LedricClient`. |
 | **[Schema](./docs/schema.md)** | Field types catalogue, `defineType()` examples, common + type-level options, validation, schema evolution. |
 | **[Agent recipes](./docs/agent-recipes.md)** | Example prompts you can paste into Claude: project setup, drafting, schema evolution, bulk ops, refactoring, localization. |
 | **[MCP tools](./docs/mcp-tools.md)** | The full 20-tool surface — args, returns, examples. Same surface as `POST /rpc` over HTTP. |
 | **[HTTP API](./docs/http-api.md)** | REST routes for reads, multipart upload, generic `POST /rpc`, image transforms, slug redirects, error codes. |
+| **[SDKs](./docs/sdks.md)** | `@ledric/sdk` (TypeScript) and `Ledric\LedricClient` (PHP) — methods, options, errors, inline-editor `refAttrs()`. |
 | **[Inline editor](./docs/inline-editor.md)** | `<script>` install, `data-ledric-ref` / `data-ledric-field` attributes, `refAttrs()` helpers in both SDKs, auth, behaviour. |
 | **[Assets](./docs/assets.md)** | The id / ref_key split, db vs local backends, uploads, image transforms, in-place bytes replacement, the transforms cache. |
-| **[Auth](./docs/auth.md)** | Roles, key minting via `init` / first boot, header formats, closed-reads mode, listing / creating / revoking, rotation, env-var override. |
-| **[SDKs](./docs/sdks.md)** | `@ledric/sdk` (TypeScript) and `Ledric\LedricClient` (PHP) — methods, options, errors, inline-editor `refAttrs()`. |
 | **[Localization](./docs/localization.md)** | Per-type locales, `localized: true` fields, the `_locale` sidecar, fallback chains, locale-specific slugs, recipes. |
+| **[Auth](./docs/auth.md)** | Roles, key minting via `init` / first boot, header formats, closed-reads mode, listing / creating / revoking, rotation, env-var override. |
+| **[Architecture](./docs/architecture.md)** | What's running when ledric boots: the packages, the storage adapters, the asset pipeline, the inline editor, process lifecycle. |
 | **[Deployment](./docs/deployment.md)** | Production shape: CDN in front of `/assets/<ref_key>`, reverse proxy + TLS, env-supplied API keys, backups, Postgres / MySQL deploys, what to handle outside of ledric. |
+| **[Why ledric](./docs/why.md)** | Honest comparison vs Contentful, Sanity, Payload, Strapi, Directus — and when ledric is the wrong choice. |
+| **[FAQ](./docs/faq.md)** | The questions that come up most: production-readiness, SQLite limits, hosting, the agent angle, migration. |
+| **[Roadmap](./docs/roadmap.md)** | What's stable, in progress, planned, and explicitly out of scope. |
 
 ## From source
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,452 @@
+# Architecture
+
+How the pieces fit together. This page exists for the operator,
+contributor, or curious reader who wants to know what's actually
+running when `npx ledric serve --gui` boots up.
+
+If you only want to *use* ledric, [`build-with-an-agent.md`](./build-with-an-agent.md)
+will get you further faster. Come back here when you need to reason
+about deployment shape, debugging, or why a particular boundary
+exists.
+
+- [The ten-thousand-foot view](#the-ten-thousand-foot-view)
+- [The packages](#the-packages)
+- [Inside the ledric process](#inside-the-ledric-process)
+- [The two-process consumer pattern](#the-two-process-consumer-pattern)
+- [Storage adapters](#storage-adapters)
+- [The asset pipeline](#the-asset-pipeline)
+- [The inline editor](#the-inline-editor)
+- [Process lifecycle](#process-lifecycle)
+
+---
+
+## The ten-thousand-foot view
+
+```
+┌────────────────────────┐         ┌────────────────────────┐
+│  Agent (Claude Code,   │         │  Browser              │
+│  Cursor, your script)  │         │  (admin GUI, inline   │
+│                        │         │  editor)              │
+└──────┬──────────┬──────┘         └────────────┬───────────┘
+       │          │                             │
+   MCP │      MCP │                       HTTPS │
+   stdio│      SSE│                             │
+       │          │                             ▼
+       │          │              ┌────────────────────────┐
+       │          │              │  Reverse proxy +       │
+       │          └──────────────│  TLS (in production)   │
+       │                         └────────────┬───────────┘
+       │                                      │
+       ▼                                      ▼
+┌────────────────────────────────────────────────────────────┐
+│  ledric process (Node 22+)                                 │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐     │
+│  │  MCP server  │  │  HTTP server │  │  Admin GUI   │     │
+│  │  (stdio +    │  │  (REST +     │  │  (static SPA │     │
+│  │   SSE)       │  │   /rpc)      │  │   served at  │     │
+│  └──────┬───────┘  └──────┬───────┘  │   /admin)    │     │
+│         │                 │          └──────┬───────┘     │
+│         └─────────┬───────┘                 │             │
+│                   ▼                         ▼             │
+│         ┌──────────────────────────────────────────┐      │
+│         │  Core (schema, validation, refs,         │      │
+│         │  versions, transforms)                   │      │
+│         └──────────────────┬───────────────────────┘      │
+│                            ▼                              │
+│         ┌──────────────────────────────────────────┐      │
+│         │  Storage (SQLite | Postgres | MySQL)     │      │
+│         │  + Asset backend (db | local fs)         │      │
+│         └──────────────────────────────────────────┘      │
+└────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+                   ┌─────────────────┐
+                   │   ledric.db     │
+                   │   (or remote    │
+                   │    Postgres /   │
+                   │    MySQL DB)    │
+                   └─────────────────┘
+```
+
+One process. One file (or one external DB). Multiple ways in (MCP,
+HTTP, admin GUI). One core doing schema/versioning/validation. A
+pluggable storage layer underneath.
+
+---
+
+## The packages
+
+ledric is a pnpm monorepo. Each package has one job.
+
+```
+packages/
+├── schema/        — defineType(), field types, validation
+├── storage/       — SQLite/Postgres/MySQL adapters + asset backends
+├── core/          — read/draft/publish/find, transforms, ref resolution
+├── mcp-server/    — registers the 20 MCP tools, dispatches to core
+├── http-server/   — Express-style routes (REST + /rpc), serves the GUI
+├── gui/           — admin SPA (React + Vite); also serves /admin/inline.js
+├── sdk/           — @ledric/sdk: TS read client + refAttrs helpers
+├── proxy/         — @ledric/proxy: server-side proxy primitive for consumers
+└── cli/           — ledric command (init, serve, get, ls, asset, keys, …)
+
+clients/
+└── php/           — ledric/sdk (Composer): PHP read client
+```
+
+Three things worth noticing:
+
+1. **Core is the single dispatch point.** Both `mcp-server` and
+   `http-server` are thin shells over `core` — they parse their
+   transport's args, call into `core`, and serialise the result
+   back. Adding a third transport (gRPC, queue-based ingestion,
+   anything) wouldn't require duplicating business logic.
+
+2. **Storage is two layers, not one.** `storage` has a dialect
+   layer (SQLite / Postgres / MySQL) and an asset-backend layer
+   (db / local). Either dimension can flex independently — you
+   can run SQLite-with-on-disk-assets or Postgres-with-in-DB-assets
+   if you want.
+
+3. **`sdk` and `proxy` are consumer-facing.** They're the
+   packages you'll add to your *consumer site's* `package.json`,
+   not ledric's. They don't import `storage` or `core` — they
+   speak HTTP to a running ledric.
+
+---
+
+## Inside the ledric process
+
+What's actually running when `ledric serve --gui` boots.
+
+### The MCP server (`packages/mcp-server`)
+
+Registers the 20 tools listed in
+[`mcp-tools.md`](./mcp-tools.md). Listens on stdio by default
+(which is what desktop MCP clients like Claude Desktop expect). It
+dispatches every `CallToolRequest` to `core`, wraps errors into
+the structured ledric error shape, and returns the result.
+
+The same tool surface is available over HTTP at `POST /rpc` —
+that path lives in `http-server`, but the dispatch goes through
+exactly the same `core` methods. There is no second
+implementation.
+
+### The HTTP server (`packages/http-server`)
+
+A handful of REST routes plus the catch-all `/rpc`:
+
+```
+GET  /                        — root: API info, endpoint list
+GET  /auth/status             — auth posture check
+GET  /types                   — same as describe_model over HTTP
+GET  /types/:name
+GET  /entries/:type           — list (paginated, filterable)
+GET  /entries/:type/:slug     — read one (with version, locale, expand opts)
+POST /assets                  — multipart upload
+GET  /assets                  — list
+GET  /assets/:id              — metadata
+GET  /assets/:id/meta         — explicit metadata
+GET  /assets/<ref_key>        — bytes (with imgix-style transforms)
+POST /rpc                     — generic dispatch to any of the 20 tools
+GET  /admin/*                 — static GUI files (when --gui is on)
+GET  /admin/inline.js         — the inline editor loader script
+```
+
+The REST routes exist because they're more ergonomic for a
+browser, a CDN, or a traditional HTTP client than `POST /rpc`
+would be. The two surfaces are equivalent — anything you can do
+over REST you can also do via `/rpc`, and vice versa.
+
+Auth lives here too: a simple middleware that reads
+`Authorization: Bearer <key>` (or env-var override) and routes
+requests to admin / reader / unauthenticated paths based on the
+key's role.
+
+### Core (`packages/core`)
+
+The brain. Owns:
+
+- **Reads.** `read`, `find`, with all the projection options
+  (`expand_assets`, `resolve_references`, `resolve_refs`,
+  `summary`, locale projection, version selection).
+- **Writes.** `draft`, `publish`, `rename_entry`, `delete_entry`,
+  `migrate_entries`. Concurrency via `parent_version`. Validation
+  via `schema`.
+- **Schema lifecycle.** `create_type`, `alter_type`, `delete_type`.
+  Computes `change_class` (`safe` / `needs_backfill` /
+  `destructive`) by diffing field definitions.
+- **Asset transforms.** `core/src/transforms.ts` wraps `sharp`
+  (libvips), parses imgix-style query parameters, and writes a
+  per-`(ref_key, params_hash)` cache to disk.
+- **Ref resolution.** `core/src/resolve-refs.ts` parses
+  `:::ref{to="…"}:::` directives in markdown fields and resolves
+  the target entries.
+- **`describe_model`.** Walks the schema, decorates with capability
+  flags, returns the whole content model.
+
+Core depends on `storage` for persistence and `schema` for type
+validation. It doesn't know about HTTP, MCP, or the admin GUI.
+
+### Schema (`packages/schema`)
+
+Pure TypeScript: `defineType()`, the field-type catalogue, the
+validator. No I/O. Imported by both consumer code (in user
+projects, via `@ledric/schema`) and by `core` for write-time
+validation.
+
+### Storage (`packages/storage`)
+
+Dialect-and-adapter pattern. The same logical operations
+(`createType`, `getEntry`, `listEntries`, `writeVersion`, …)
+implemented three times (SQLite, Postgres, MySQL) on the
+dialect side, and twice (db-resident, local filesystem) on
+the asset-bytes side.
+
+Tests run against real databases when `LEDRIC_TEST_POSTGRES_URL`
+or `LEDRIC_TEST_MYSQL_URL` are set; the default `pnpm test` is
+SQLite-only.
+
+### Admin GUI (`packages/gui`)
+
+A React + Vite SPA. Built into static files at install time;
+served by `http-server` under `/admin/`. State management is
+plain React; data fetching is the `@ledric/sdk` client pointed at
+the same origin.
+
+`/admin/inline.js` is also served by this package — the script
+is small, framework-free vanilla JS, and is loaded by consumer
+sites with a single `<script>` tag.
+
+### CLI (`packages/cli`)
+
+Wraps everything. `ledric init` walks first-time setup; `ledric
+serve` boots the MCP server (with optional `--http` and `--gui`
+flags); `ledric ls` / `get` / `asset` are admin-side reads; `ledric
+keys` mints and revokes API keys; `ledric types` codegens
+TypeScript from your schema; `ledric refs check` lints inline refs
+across all your markdown fields.
+
+Full CLI surface is documented per-command in `ledric --help`.
+
+---
+
+## The two-process consumer pattern
+
+```
+┌──────────────────────┐                ┌──────────────────────┐
+│  ledric process       │                │  Consumer process     │
+│  (the CMS)            │                │  (Astro, Next, PHP,   │
+│                       │                │   plain HTML, …)      │
+│  npx ledric serve     │                │  npm run dev          │
+│                       │                │                       │
+│  - MCP stdio          │                │  - imports @ledric/sdk│
+│  - HTTP API           │ ◄── HTTP ──►  │  - calls client.read()│
+│  - Admin GUI          │                │  - renders pages      │
+│  - libsharp + sqlite  │                │  - serves /admin/inline.js│
+└──────────────────────┘                └──────────────────────┘
+        ./ledric.db                          ./astro.config.mjs
+```
+
+The consumer site is **a different process in a different
+directory**. It does not import `ledric` itself. It imports
+`@ledric/sdk` (TS) or `ledric/sdk` (PHP) — read clients that
+speak HTTP to the running ledric process.
+
+Why:
+
+- **Build-size hygiene.** `better-sqlite3` and `sharp` are heavy
+  native modules. Your Vercel build (or your Lambda cold start)
+  doesn't need them.
+- **Independent scaling.** ledric handles writes and admin
+  traffic; consumer renderers handle reads-and-render. Different
+  shapes, different machines.
+- **Same SDK, many stacks.** Astro, Next, Remix, plain HTML +
+  htmx, vanilla PHP, Twig templates — they all hit the same HTTP
+  surface with the same client shape. There's no
+  framework-specific deep integration to maintain.
+
+For local dev convenience, the two processes are usually started
+side by side. Production deploys put a CDN in front of
+`/assets/<ref_key>`, a reverse proxy in front of everything else,
+and run the consumer site on its own host fleet that fetches from
+ledric over the network.
+
+When the consumer needs admin-level reach (versioned reads,
+asset uploads, write operations) without leaking the admin key
+into the browser, it mounts `@ledric/proxy` server-side. The
+proxy holds the admin key in environment variables and exposes
+a curated subset of ledric's surface to the browser.
+
+---
+
+## Storage adapters
+
+The storage package implements the same logical interface three
+times.
+
+```
+storage/
+├── interface.ts           — the methods every dialect implements
+├── dialects/
+│   ├── sqlite.ts          — better-sqlite3, WAL mode, FTS5
+│   ├── postgres.ts        — pg, tsvector FTS
+│   └── mysql.ts           — mysql2, FULLTEXT FTS
+└── assets/
+    ├── backend.ts         — the asset-bytes interface
+    ├── db.ts              — bytes in an asset_blobs table
+    └── local.ts           — bytes on disk, keyed by ref_key
+```
+
+Capability differences are reported through `describe_model`'s
+`capabilities` block:
+
+```json
+{
+  "capabilities": {
+    "vectorSearch": false,
+    "nativePubSub": false,
+    "fts": "fts5"
+  }
+}
+```
+
+`fts` is one of `fts5` (SQLite), `tsvector` (Postgres), or
+`fulltext` (MySQL). Vector search and native pub/sub are reserved
+capability flags for features that aren't shipped — see
+[`roadmap.md`](./roadmap.md).
+
+---
+
+## The asset pipeline
+
+```
+┌──────────────────┐
+│ Upload           │  POST /assets (multipart)
+│ (HTTP only)      │
+└────────┬─────────┘
+         ▼
+┌──────────────────┐
+│ Asset record     │  assets table: id, ref_key, kind, version,
+│                  │  meta (json: width, height, mime, alt, …)
+└────────┬─────────┘
+         ▼
+┌──────────────────┐  asset_blobs (db backend) OR
+│ Bytes            │  ./assets/<ref_key>.bin (local backend)
+└────────┬─────────┘
+         ▼
+GET /assets/<ref_key>?w=800&fm=webp
+         │
+         ▼
+┌──────────────────┐
+│ Transform cache  │  ./.ledric-cache/transforms/<key>.bin
+│ (libvips/sharp)  │  (cache miss → render → write → serve)
+└────────┬─────────┘
+         ▼
+   Bytes back
+```
+
+URLs are version-pinned via `ref_key`. Replacing the bytes mints
+a new `ref_key` and therefore a new URL — CDN caches invalidate
+themselves. Old URLs keep serving old bytes until you prune them
+(no automatic GC yet).
+
+The transform cache lives next to the database file (`.ledric-cache/`
+by default) and is just files keyed by `(ref_key, params_hash)`.
+Safe to delete; will be regenerated on next request.
+
+For the full asset story — uploads, transforms, in-place
+replacement, the cache layout — see [`assets.md`](./assets.md).
+
+---
+
+## The inline editor
+
+```
+Consumer site HTML
+┌───────────────────────────────────────────────┐
+│ <article data-ledric-ref="blog_post/hello">  │
+│   <h1 data-ledric-ref="blog_post/hello"      │
+│       data-ledric-field="title">Hello</h1>    │
+│   <div data-ledric-ref="..."                  │
+│        data-ledric-field="body">…</div>       │
+│ </article>                                    │
+│                                                │
+│ <script src="<ledric>/admin/inline.js"></script>│
+└───────────────────────────────────────────────┘
+                  │
+                  │ (script walks the DOM, attaches
+                  │  hover handlers to data-ledric-ref
+                  │  elements)
+                  ▼
+       Hover → pencil icon → click
+                  │
+                  ▼
+       Drawer: form for the entry, scrolled
+       to the field that was clicked
+                  │
+                  ▼
+       Save → POST through the admin API →
+       new version → publish → page reloads
+```
+
+Three pieces working together:
+
+1. **`refAttrs(entry)` / `refAttrs(entry, field)` SDK helpers**
+   emit the `data-ledric-ref` and `data-ledric-field` attributes
+   on the consumer-rendered HTML.
+2. **`/admin/inline.js`** is loaded by the consumer site (one
+   `<script>` tag). It walks the DOM looking for those
+   attributes, attaches mouseenter/click listeners, and renders
+   the floating pencil + drawer.
+3. **The drawer's form** is the same form `gui/` uses for the
+   admin entry editor. It's served by ledric's HTTP server, so
+   validation, version conflict handling, and save semantics are
+   identical between the two surfaces.
+
+The script is small and framework-free; it works on any rendered
+HTML regardless of the consumer's stack. See
+[`inline-editor.md`](./inline-editor.md) for the full attribute
+reference and behavioural details.
+
+---
+
+## Process lifecycle
+
+What `ledric serve --gui` does, in order:
+
+1. **Read config.** `ledric.config.json` if present; otherwise
+   defaults (SQLite at `./ledric.db`, port 3000, `/admin` for
+   the GUI).
+2. **Open storage.** Dialect chosen from the DB connection
+   string. SQLite opens the file (creating it if missing);
+   Postgres / MySQL connect to the configured URL. Migrations
+   run automatically — every bootup converges the schema.
+3. **First-boot key minting.** If no API keys exist, mint an
+   admin and a reader key, write them to `.env.local` (CLI
+   path) or print them to stdout (programmatic path).
+4. **Boot the MCP server.** Stdio transport wired up; tool
+   handlers registered.
+5. **Boot the HTTP server.** REST routes mounted, `/rpc`
+   mounted, GUI static files mounted (with `--gui`),
+   `/admin/inline.js` served.
+6. **Listen.** MCP on stdio. HTTP on the configured port.
+   Process stays up until killed.
+
+Every request — whether MCP `read` or HTTP `GET /entries/...`
+— routes through `core`, which routes through `storage`, which
+talks to the underlying database. There's no internal queue, no
+worker pool, no separate process for renders. It's a Node
+event-loop process with the usual concurrency story.
+
+---
+
+## Where to go next
+
+- [Build a site with an agent](./build-with-an-agent.md) — see all
+  this in motion against a working Astro example.
+- [Deployment](./deployment.md) — what changes in production
+  (CDN, reverse proxy, Postgres / MySQL, backups).
+- [MCP tools](./mcp-tools.md) — every tool the dispatch table
+  knows about.
+- [HTTP API](./http-api.md) — every route the HTTP server exposes.

--- a/docs/build-with-an-agent-php.md
+++ b/docs/build-with-an-agent-php.md
@@ -1,0 +1,499 @@
+# Build a site with an agent — PHP
+
+The PHP counterpart to [`build-with-an-agent.md`](./build-with-an-agent.md).
+Same blog example, same agent flow — `describe_model` → `create_type`
+→ seed → render → wire up the inline editor — but the consumer side
+is plain PHP using `Ledric\LedricClient`.
+
+> **A note on the artifact.** The TypeScript walkthrough is anchored
+> to a committed [`examples/astro-blog/`](../examples/astro-blog/) you
+> can clone and run. There isn't a committed `examples/blog-php/` yet
+> — the existing [`examples/blog/`](../examples/blog/) is a vanilla
+> HTML + fetch demo. The PHP code below is the one you'd write today
+> with the shipped SDK; an issue is open to commit a runnable
+> example next to the Astro one.
+
+- [Before you start](#before-you-start)
+- [Setting up the schema](#setting-up-the-schema)
+- [Seeding some content](#seeding-some-content)
+- [Building the frontend](#building-the-frontend)
+- [Making it editable in place](#making-it-editable-in-place)
+- [What just happened](#what-just-happened)
+- [Other PHP stacks](#other-php-stacks)
+
+---
+
+## Architecture: ledric and your PHP site are separate processes
+
+Same as the Astro version: ledric runs in **its own process** and
+your PHP consumer is a **different project** that fetches over HTTP.
+
+```
+[ ./ledric-content/  ]      [ ./my-site-php/         ]
+     ↓ runs                       ↓ runs
+[ npx ledric serve ]  ←  HTTP  ←  [ php -S localhost:8000 ]
+   (one Node process)               (one PHP process)
+   exposes :3000                    fetches LEDRIC_API_URL
+```
+
+The PHP side never imports anything from ledric directly. It pulls
+in `ledric/sdk` from Composer and that's it — `ext-curl` and
+`ext-json` are the only PHP requirements.
+
+---
+
+## Before you start
+
+You need:
+
+- Node 22+ (for ledric itself)
+- PHP 7.4+ with `ext-curl` and `ext-json`
+- Composer
+- An MCP-speaking client — Claude Code or Claude Desktop, ideally
+
+A 60-second setup:
+
+```bash
+mkdir my-content && cd my-content      # ← ledric's directory
+npx -y ledric init
+# accept defaults — patches .mcp.json, mints keys, writes .gitignore
+npx ledric serve --gui &
+# admin GUI at http://localhost:3000/admin
+
+claude    # start Claude Code in this directory
+```
+
+Because `init` patched `./.mcp.json`, Claude Code picks up the ledric
+MCP server automatically. Confirm it's connected:
+
+> What MCP tools do you have access to right now?
+
+It should list the 20 ledric tools.
+
+You'll scaffold the PHP consumer in a sibling directory
+(`../my-site-php/` or wherever) — not inside `my-content/`.
+
+---
+
+## Setting up the schema
+
+Same prompt as the Astro walkthrough — the schema is identical
+regardless of consumer language.
+
+> Set up a blog. Posts have a title (required, capped at 120 chars),
+> a slug derived from the title, a markdown body, an optional hero
+> image, an author reference, a short summary, a published date, and
+> a tags string array. Title is what shows in admin lists; show
+> title, author, and published_at in summary views.
+>
+> Then add an author type with name (required), bio (markdown), and
+> avatar (image asset).
+
+What Claude does:
+
+1. **`describe_model`** — to see whether the types already exist and
+   to remind itself of the field-type catalogue.
+2. **`create_type` for `author`** first (because `blog_post`
+   references it).
+3. **`create_type` for `blog_post`** with the `references` field
+   pointing at `author`.
+
+Verify with the CLI:
+
+```bash
+npx ledric ls
+# {
+#   "db": "./ledric.db",
+#   "types": [
+#     { "name": "author",    "version": 1, "entries": 0 },
+#     { "name": "blog_post", "version": 1, "entries": 0 }
+#   ]
+# }
+```
+
+For details of what each `create_type` call looks like and how the
+agent infers `min`/`max` cardinality from the prompt, see the
+[Astro walkthrough's schema section](./build-with-an-agent.md#setting-up-the-schema).
+The wire shape is identical — only the consumer that renders the
+result differs.
+
+---
+
+## Seeding some content
+
+Same prompt:
+
+> Draft three blog posts. Pick realistic titles, write 3-paragraph
+> bodies, give them sensible published dates from the last few
+> months. Authors can be made up — create one or two `author`
+> entries first if you need to.
+
+Claude drafts authors and posts via `draft`, then asks if you want
+them published. Tell it yes:
+
+> Publish all three posts.
+
+`publish` once per entry. They're live.
+
+---
+
+## Building the frontend
+
+Switch contexts. The schema and content are in place; now ask for a
+PHP site that renders them.
+
+> Build me a small PHP site in this directory that consumes the blog
+> from ledric. Use plain PHP (no framework) and PHP's built-in dev
+> server. Index page lists posts (title, summary, hero image, date).
+> A post detail page renders the full post — title, hero, body as
+> rendered markdown, author, tags. Use the `ledric/sdk` Composer
+> package for reads.
+
+What Claude does:
+
+1. **`describe_model`** — re-grounds on the schema before writing
+   the renderer.
+2. **`composer init`** with sensible defaults.
+3. **`composer require ledric/sdk league/commonmark`** — the SDK
+   plus a markdown renderer.
+4. **Writes `lib/ledric.php`** — a thin module that exports a
+   shared `LedricClient` instance and a few helpers.
+5. **Writes `index.php`** — the post-list page.
+6. **Writes `post.php`** — the detail page (looks up by `?slug=`).
+7. **Writes a tiny `router.php`** so PHP's built-in server routes
+   pretty URLs to the right script.
+
+The actual files end up looking like this.
+
+`composer.json` (the relevant bits):
+
+```json
+{
+  "require": {
+    "php": "^8.0",
+    "ledric/sdk": "^0.2",
+    "league/commonmark": "^2"
+  },
+  "autoload": {
+    "files": ["lib/ledric.php"]
+  }
+}
+```
+
+`lib/ledric.php` — the thin shared module:
+
+```php
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Ledric\LedricClient;
+
+function ledric(): LedricClient {
+    static $client = null;
+    if ($client === null) {
+        $client = new LedricClient(
+            getenv('LEDRIC_API') ?: 'http://localhost:3000'
+        );
+    }
+    return $client;
+}
+
+function isAssetId($v): bool {
+    return is_string($v) && preg_match('/^[0-9a-f]{32}$/i', $v) === 1;
+}
+
+function formatDate($s): string {
+    if (!is_string($s) || $s === '') return '';
+    $ts = strtotime($s);
+    return $ts !== false ? date('M j, Y', $ts) : '';
+}
+
+function renderMarkdown(string $md): string {
+    static $converter = null;
+    if ($converter === null) {
+        $converter = new \League\CommonMark\CommonMarkConverter([
+            'html_input' => 'allow',
+            'allow_unsafe_links' => false,
+        ]);
+    }
+    return (string) $converter->convert($md);
+}
+```
+
+`index.php` — the list view:
+
+```php
+<?php
+require_once __DIR__ . '/lib/ledric.php';
+
+$result = ledric()->find('blog_post', ['limit' => 20]);
+$posts = array_map(function ($p) {
+    $f = $p['fields'] ?? [];
+    return [
+        'slug'        => $p['slug'],
+        'title'       => is_string($f['title'] ?? null) ? $f['title'] : '(untitled)',
+        'summary'     => is_string($f['summary'] ?? null) ? $f['summary'] : '',
+        'publishedAt' => formatDate($f['published_at'] ?? null),
+        'heroId'      => isAssetId($f['hero'] ?? null) ? $f['hero'] : null,
+        'tags'        => is_array($f['tags'] ?? null) ? $f['tags'] : [],
+        'entry'       => $p,
+    ];
+}, $result['results'] ?? []);
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>The latest from the team</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1>The latest from the team</h1>
+  <ul class="post-list">
+  <?php foreach ($posts as $p): ?>
+    <li class="post-card">
+      <?php if ($p['heroId']): ?>
+        <img src="<?= htmlspecialchars(ledric()->assetUrl($p['heroId'], ['w' => 800])) ?>"
+             alt="<?= htmlspecialchars($p['title']) ?>">
+      <?php endif; ?>
+      <h2><a href="/posts/<?= rawurlencode($p['slug']) ?>"><?= htmlspecialchars($p['title']) ?></a></h2>
+      <div class="meta"><?= htmlspecialchars($p['publishedAt']) ?></div>
+      <?php if ($p['summary'] !== ''): ?>
+        <p><?= htmlspecialchars($p['summary']) ?></p>
+      <?php endif; ?>
+      <?php if (!empty($p['tags'])): ?>
+        <div class="tags">
+          <?php foreach ($p['tags'] as $t): ?>
+            <span><?= htmlspecialchars((string) $t) ?></span>
+          <?php endforeach; ?>
+        </div>
+      <?php endif; ?>
+    </li>
+  <?php endforeach; ?>
+  </ul>
+  <script src="<?= htmlspecialchars(ledric()->getBaseUrl()) ?>/admin/inline.js" defer></script>
+</body>
+</html>
+```
+
+`post.php` — the detail view:
+
+```php
+<?php
+require_once __DIR__ . '/lib/ledric.php';
+
+use Ledric\LedricClient;
+
+$slug = $_GET['slug'] ?? null;
+$post = is_string($slug) ? ledric()->read("blog_post/{$slug}") : null;
+
+if ($post === null) {
+    http_response_code(404);
+    echo 'Not found';
+    return;
+}
+
+$f = $post['fields'] ?? [];
+$title  = is_string($f['title'] ?? null) ? $f['title'] : '(untitled)';
+$body   = is_string($f['body']  ?? null) ? $f['body']  : '';
+$heroId = isAssetId($f['hero'] ?? null) ? $f['hero'] : null;
+$bodyHtml = renderMarkdown($body);
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title><?= htmlspecialchars($title) ?></title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <article <?= LedricClient::refAttrsHtml($post) ?>>
+    <?php if ($heroId): ?>
+      <img class="hero"
+           src="<?= htmlspecialchars(ledric()->assetUrl($heroId, ['w' => 1200])) ?>"
+           alt="<?= htmlspecialchars($title) ?>"
+           <?= LedricClient::refAttrsHtml($post, 'hero') ?>>
+    <?php endif; ?>
+    <h1 <?= LedricClient::refAttrsHtml($post, 'title') ?>>
+      <?= htmlspecialchars($title) ?>
+    </h1>
+    <div class="meta" <?= LedricClient::refAttrsHtml($post, 'published_at') ?>>
+      <?= htmlspecialchars(formatDate($f['published_at'] ?? null)) ?>
+    </div>
+    <div class="prose" <?= LedricClient::refAttrsHtml($post, 'body') ?>>
+      <?= $bodyHtml ?>
+    </div>
+  </article>
+  <script src="<?= htmlspecialchars(ledric()->getBaseUrl()) ?>/admin/inline.js" defer></script>
+</body>
+</html>
+```
+
+`router.php` — for PHP's built-in dev server, so `/posts/hello-world`
+routes to `post.php?slug=hello-world`:
+
+```php
+<?php
+$path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?? '/';
+
+// Static assets: let the built-in server handle them.
+if (preg_match('/\.(css|js|png|jpe?g|svg|ico|woff2?)$/i', $path)) {
+    return false;
+}
+
+// /posts/<slug> → post.php?slug=<slug>
+if (preg_match('#^/posts/([^/]+)/?$#', $path, $m)) {
+    $_GET['slug'] = rawurldecode($m[1]);
+    require __DIR__ . '/post.php';
+    return true;
+}
+
+// Everything else → index.php
+require __DIR__ . '/index.php';
+return true;
+```
+
+Three things worth pausing on, same as the Astro version:
+
+1. **The agent never asked you for the schema.** It called
+   `describe_model` and read it. The `array_map` shape on the index
+   page directly reflects the field types — `title: string`,
+   `summary: string`, `hero: asset` (resolved via `assetUrl`),
+   `tags: array`.
+
+2. **The reads are typed at the runtime boundary, not by codegen.**
+   The PHP SDK returns associative arrays (not objects), so the
+   per-field `is_string` / `isAssetId` checks are doing the same
+   defensive narrowing the TypeScript version did with `typeof` and
+   `as Record<string, unknown>`. There's no codegen step — the
+   wire format is the contract.
+
+3. **The body is just markdown.** `league/commonmark` parses it. If
+   you want a different markdown library (`erusev/parsedown`,
+   `michelf/php-markdown`), the same string flows in. ledric stores
+   markdown verbatim — no SDK lock-in.
+
+Run it:
+
+```bash
+php -S localhost:8000 router.php
+```
+
+Live data from the live ledric instance. Edit a post in the admin
+GUI at `:3000/admin`, hit publish, refresh `:8000` — the change shows
+up on next request (no caching beyond what the browser does).
+
+---
+
+## Making it editable in place
+
+The site renders. Now wire up the inline editor so you can
+click-edit on the rendered page.
+
+> Add the inline editor. I should be able to hover anything and get
+> a pencil icon that opens the edit drawer.
+
+The agent's actual changes:
+
+1. **The `<script src=".../admin/inline.js">` tag** is already in
+   the templates above. (Claude tends to add it on the first pass
+   when it knows the inline editor is coming. If yours doesn't,
+   just ask it to.)
+2. **`LedricClient::refAttrsHtml($post)`** on the post wrapper —
+   already there in `post.php`.
+3. **Field-scoped attrs** — `LedricClient::refAttrsHtml($post,
+   'title')` on the heading, `'body'` on the content, etc.
+
+Reload `/posts/hello-world`. Hover the title. Pencil appears.
+Click it. Drawer slides in, scrolled to the title field. Edit,
+save — page reloads with the new published content.
+
+The ergonomics in PHP are slightly noisier than in JSX (no spread
+operator), but the helper does the work. `refAttrsHtml` returns
+a single pre-escaped string that drops directly into an HTML
+attribute position with `<?= ... ?>`. There's also `refAttrs()`
+that returns an associative array of `data-*` keys if you want to
+build the HTML differently (e.g. inside a Twig macro that loops
+over attributes).
+
+---
+
+## What just happened
+
+The same bullets as the Astro walkthrough, with PHP-specific notes:
+
+**The schema is the API.** Zero type definitions in your PHP code.
+The agent read the schema once via `describe_model` and that was
+the spec.
+
+**`describe_model` is the discovery primitive.** Claude called it
+twice: once before creating types, once when starting the PHP
+consumer. The same in-context handoff works regardless of what
+language ends up rendering the result.
+
+**Validation drives correctness.** When Claude's first draft of a
+post fails validation (e.g. `summary` over the max length, or
+`body: null` when required), the structured error tells it the
+field path and code. It corrects and retries on its own.
+
+**Tokens stay cheap.** The list page used `find` with the default
+summary budget (`title`, `author`, `published_at` per result, not
+the full body of every post). The detail page used `read` without
+`expandAssets`, building the URL from the asset id manually with
+`assetUrl()`.
+
+**Inline editing is plumbing-free.** `LedricClient::refAttrsHtml`
+plus one script tag. The drawer is the same form the admin GUI
+uses; validation and version conflict handling are identical
+between the surfaces.
+
+The shape of this build — `lib/ledric.php`, `index.php`, `post.php`,
+`router.php`, the Composer file — totals about 200 lines of PHP.
+That's the entire consumer for a working blog.
+
+---
+
+## Other PHP stacks
+
+The pattern is the same wherever you can `composer require
+ledric/sdk` and emit HTML.
+
+**Twig** — the templates above translate directly. `getEnvironment()`
+the Twig instance once, render with `$client->read(...)` data, use
+the global function approach to expose `LedricClient::refAttrsHtml`
+to templates. Inline editor doesn't care.
+
+**Laravel** — `composer require ledric/sdk`, register the
+`LedricClient` as a singleton in a service provider, inject it into
+controllers. Blade templates work the same way as the PHP files
+above; use `{!! \Ledric\LedricClient::refAttrsHtml($post, 'title')
+!!}` for unescaped attribute output.
+
+**Symfony / Slim / etc.** — all the same shape. The SDK has zero
+framework dependencies.
+
+**Static-site builds** — a tiny PHP CLI script that loops over
+`ledric()->find('blog_post', ...)` and writes one HTML file per
+result. The inline editor still works on the static output (it
+walks the rendered DOM at runtime regardless of how the page was
+generated).
+
+The thread connecting all of these: the agent learns your model
+once via `describe_model`, picks the right SDK shape for the
+target language, and writes code that consumes the same flat-JSON
+shape you'd see at `GET /entries/blog_post/why-kysely`.
+
+---
+
+## Where to go next
+
+- [The TypeScript walkthrough](./build-with-an-agent.md) — the
+  side-by-side comparison.
+- [SDKs](./sdks.md) — the full PHP method surface, options, and
+  errors.
+- [Inline editor](./inline-editor.md) — the attribute reference and
+  behavioural details.
+- [Agent recipes](./agent-recipes.md) — more example prompts you can
+  paste into Claude.

--- a/docs/build-with-an-agent.md
+++ b/docs/build-with-an-agent.md
@@ -17,6 +17,10 @@ or Opus) actually behaves over MCP, not a literal recording.
 > shape of Claude's tool calls. **What's illustrative:** specific
 > response wording and turn counts will vary by model and session.
 
+If "type", "entry", "slug", "version", or "ref" are unfamiliar
+words on a ledric page, [`concepts.md`](./concepts.md) is the
+five-minute primer that grounds the rest.
+
 - [Before you start](#before-you-start)
 - [Setting up the schema](#setting-up-the-schema)
 - [Seeding some content](#seeding-some-content)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,507 @@
+# Concepts
+
+The mental model behind ledric, in one page. Everything else in the
+docs assumes you've internalised these.
+
+If you've used Contentful, Sanity, Payload, or Strapi, most of this
+will sound familiar — there's a content type, there's an entry, there's
+a slug, there's an asset. What's worth paying attention to is the
+*shape* of each one: ledric's are flatter, more verbatim, and more
+LLM-legible than you might be used to.
+
+- [Types and entries](#types-and-entries)
+- [Identifiers: id, slug, ref](#identifiers-id-slug-ref)
+- [Versions](#versions)
+- [References: structural and inline](#references-structural-and-inline)
+- [Assets](#assets)
+- [Locales](#locales)
+- [Environments](#environments)
+- [The wire format](#the-wire-format)
+
+For the field-type catalogue and validation rules, see
+[`schema.md`](./schema.md). For the actual tool calls that operate on
+these concepts, see [`mcp-tools.md`](./mcp-tools.md).
+
+---
+
+## Types and entries
+
+A **type** is a content shape: a name plus a map of fields. `blog_post`
+is a type. `author` is a type. `pricing_table_section` is a type. A
+type is just a row in the `types` table with a JSON schema attached
+to it.
+
+An **entry** is one instance of a type: one specific blog post, one
+specific author. It's a row in the `entries` table that points at its
+type and carries a JSON content blob shaped according to the type's
+fields.
+
+```
+types                 entries
+┌────────────┐       ┌─────────────────────────────────────┐
+│ blog_post  │ ───── │ blog_post / hello-world             │
+│  schema:   │       │   { title: "Hello", body: "...", … }│
+│   title    │       │                                     │
+│   slug     │ ───── │ blog_post / why-sqlite              │
+│   body     │       │   { title: "Why SQLite", body: …   }│
+│   …        │       └─────────────────────────────────────┘
+└────────────┘
+```
+
+Two practical consequences:
+
+1. **The schema is enforced at write time.** A `draft` or `publish`
+   that doesn't match the type's field rules comes back as a
+   structured `VALIDATION_FAILED` error with field paths — not a
+   500.
+
+2. **Types evolve in place.** You don't rewrite a type to add a
+   field; you `alter_type` it with a JSON Merge Patch. ledric
+   classifies the change as `safe`, `needs_backfill`, or
+   `destructive` and lets you `migrate_entries` if the existing
+   rows need to catch up. See [`schema.md`'s "Evolving a schema"
+   section](./schema.md#evolving-a-schema).
+
+Throughout the API and tools, types are referred to by name
+(`blog_post`) and entries are addressed by `type/slug`
+(`blog_post/hello-world`).
+
+---
+
+## Identifiers: id, slug, ref
+
+Every entry has two identifiers. They mean different things and are
+useful in different places.
+
+### `id` — UUIDv7
+
+The immutable primary key. Time-ordered (so a btree index on it
+clusters by creation time). Survives any number of slug renames.
+
+```
+018f2d40-2b18-7d92-9cf1-1b2934a7e9b3
+```
+
+Use ids in:
+
+- **Machine-to-machine integrations.** A webhook payload, a build
+  pipeline, a foreign system that should keep working when an
+  editor renames a post.
+- **Anywhere a slug rename would silently break.** Saved searches,
+  analytics events, audit logs.
+
+### `slug` — mutable URL alias
+
+The human-readable identifier. Lowercase, alphanumeric, hyphens —
+shaped to go in a URL. Unique within a type within a locale.
+
+```
+hello-world
+why-we-built-ledric
+```
+
+Slugs are **mutable**: rename a post and ledric retires the old slug
+into `slug_history` and starts redirecting reads of the old slug to
+the new entry (with a 301 + a `_redirect` sidecar in the response).
+You don't lose the inbound link.
+
+Use slugs in:
+
+- **URLs.** They're literally what the URL contains.
+- **Prompts and diffs.** `blog_post/hello-world` is legible in a
+  conversation; the UUID isn't.
+- **Anywhere an LLM is editing.** Slugs read like words; ids look
+  like noise. The difference shows up in token efficiency and in
+  how often the model picks the right entry.
+
+### `ref` — what the API accepts
+
+Every tool that takes "an entry" accepts a **ref**: any of the
+following resolves to the same row.
+
+| Form | Example | When |
+|---|---|---|
+| `type/slug` | `blog_post/hello-world` | Default. Most ergonomic. |
+| `id` | `018f2d40-2b18-7d92-…` | Stable across renames. |
+| Object | `{ type: "blog_post", slug: "hello-world" }` | When you've already split the parts. |
+| Object | `{ id: "018f2d40-…" }` | Same, with id. |
+
+The TS and PHP SDKs accept all four. `read('blog_post/hello-world')`
+and `read({ type: 'blog_post', slug: 'hello-world' })` are
+interchangeable.
+
+### Slug history
+
+When you rename `blog_post/foo` to `blog_post/bar`:
+
+1. The entry's `slug` becomes `bar`.
+2. A row goes into `slug_history`: `(type, slug=foo, entry_id, retired_at)`.
+3. Reads against `blog_post/foo` look up `slug_history`, find the
+   entry, and return it with `_redirect: { to: "bar" }`. Over HTTP
+   that comes with a `301 Moved Permanently` and a `Location` header
+   pointing at `/entries/blog_post/bar`.
+4. The redirect lasts forever by default. Old slugs aren't recycled.
+
+Per-type policy lets you opt out:
+`on_slug_change: 'redirect' | 'error' | 'silent'`. The default
+(`redirect`) is what you almost always want.
+
+---
+
+## Versions
+
+Every write to an entry creates a new version. Nothing is overwritten
+in place.
+
+```
+entries                       entry_versions
+┌──────────────────────┐      ┌───────────────────────────────────┐
+│ blog_post / hello    │  ──> │ v1 { title: "Hello", body: "..." }│
+│  current_version: 4  │      │ v2 { title: "Hello!", body: ...   │
+│  published_version: 3│      │ v3 { title: "Hello, world", ...   │ ← published_version
+└──────────────────────┘      │ v4 { title: "Hello, world", ...   │ ← current_version
+                              └───────────────────────────────────┘
+```
+
+Three things flow from this:
+
+### 1. Drafting and publishing are decoupled
+
+`draft` writes a new version. The entry's `current_version` advances.
+The `published_version` pointer stays where it was. Public reads keep
+returning the previously-published shape.
+
+`publish` moves the `published_version` pointer. That's it — no copy,
+no separate "published table". Publishing is a pointer move and
+unpublishing is the same move in reverse.
+
+### 2. Reads can target a version
+
+```
+read({ ref: 'blog_post/hello', version: 'published' })  // default for published reads
+read({ ref: 'blog_post/hello', version: 'current' })    // latest draft
+read({ ref: 'blog_post/hello', version: 7 })            // specific historical version
+```
+
+Same shape, different content. Handy for restoring an older revision
+(diff the JSON, copy the bits you want, draft them back) and for
+admin tooling that wants to render history.
+
+### 3. `parent_version` is optimistic concurrency
+
+Every mutating tool that touches an existing row takes
+`parent_version`. If the row's actual version doesn't match, the
+write is rejected with a `VERSION_CONFLICT` error. Two agents
+editing the same entry don't silently clobber each other — the
+second one gets told to re-read and try again.
+
+```json
+{
+  "tool": "draft",
+  "args": {
+    "ref": "blog_post/hello",
+    "parent_version": 4,
+    "fields": { "title": "Hello, world" }
+  }
+}
+```
+
+If the entry is at version 5 by the time this lands:
+
+```json
+{
+  "error": {
+    "code": "VERSION_CONFLICT",
+    "current_version": 5,
+    "your_parent_version": 4
+  }
+}
+```
+
+### Schema-version stamping
+
+Every entry version also records the schema version it was written
+under. After an `alter_type`, old entries keep reading correctly
+against the version of the schema they were written for; the
+`migrate_entries` tool re-validates them against the new shape and
+backfills as needed.
+
+### What's not exposed yet
+
+The original spec describes `read_version`, `revert`, `diff`, and
+`list_versions` as MCP tools. Those aren't shipped. You can pass
+`version: N` to `read` to fetch any historical version; everything
+else (diffing, reverting, listing) is HTTP-callable but not yet
+surfaced as a first-class tool. See [`roadmap.md`](./roadmap.md).
+
+---
+
+## References: structural and inline
+
+Two ways one entry can point at another. They have different rules
+and different jobs.
+
+### Structural references — schema fields
+
+A `references` field type, declared in the schema, with a target
+type and cardinality.
+
+```ts
+field.references({ to: ['author'], min: 1, max: 1 })   // exactly one author
+field.references({ to: ['post', 'page'], max: 6 })     // up to 6 related entries
+```
+
+Properties:
+
+- **Validated at write time.** The target entries must exist (or
+  the write is rejected with `REFERENCE_NOT_FOUND`).
+- **Queryable.** You can `find` entries by their references with the
+  HTTP filter DSL.
+- **Reverse-indexable.** Soft-deleting a referenced entry surfaces
+  the dependents in the structured `REFERENCE_TOMBSTONED` error.
+
+Use structural references for **app-logic dependencies**: a post's
+author, a page's section list, a product's category.
+
+### Inline references — `:::ref{…}:::` directives
+
+A directive embedded inside any markdown field, resolved at read
+time.
+
+```markdown
+For background, see :::ref{to="blog_post/why-sqlite"}:::.
+
+Pricing details: :::ref{to="section/pricing-table"}:::
+```
+
+The directive is just a string in the body. It's parsed and
+optionally resolved on read:
+
+```ts
+const post = await client.read('blog_post/hello-world', { resolveRefs: true });
+post._refs;  // [{ to: "blog_post/why-sqlite", found: true, url: "...", entry: {...} }]
+```
+
+Properties:
+
+- **Resolved at render time, not write time.** Dangling refs warn,
+  they don't block the write. The `ledric refs check` CLI command
+  will lint a whole content set for danglers.
+- **Not queryable.** They live inside opaque markdown.
+- **Pinnable.** `:::ref{to="blog_post/hello" version=42}:::` freezes
+  the reference to a specific version. Useful when published
+  content shouldn't drift if a referenced entry changes later.
+
+Use inline references for **editorial links in flowing prose**: the
+"see also" in a paragraph, an embedded section block in the middle
+of a long-form post.
+
+### Quick rule of thumb
+
+If a renderer has to know about it to lay out the page, it's a
+structural ref. If it's something a writer typed in the body, it's
+inline.
+
+---
+
+## Assets
+
+Uploaded files — images, PDFs, videos, anything else. Two kinds of
+identifier, for two different reasons.
+
+### `id` — the asset's identity
+
+A 32-char hex string. Stable for the lifetime of the asset.
+
+```
+019dc0b5553477e894374b563cd4e633
+```
+
+This is what gets stored in an `asset` field on an entry. Replace
+the bytes (re-upload to the same id) and every entry that points
+at it picks up the new bytes automatically.
+
+### `ref_key` — the version-pinned bytes locator
+
+A separate token tied to a specific upload. Changes when you
+replace the bytes.
+
+```
+abc123def456...
+```
+
+Asset URLs use the `ref_key`, not the id:
+
+```
+/assets/abc123def456...?w=800&fit=crop&auto=format
+```
+
+This is deliberate. CDNs and browser caches key on URL. If the URL
+contained the id, replacing the bytes wouldn't invalidate caches —
+visitors would see stale images for hours. Because the URL contains
+the `ref_key`, replacing the bytes mints a new URL, and caches
+re-fetch automatically. Old URLs keep serving old bytes (if you
+haven't pruned them) — historical pages stay stable.
+
+### Image transforms
+
+Asset URLs accept imgix-style query parameters: `w`, `h`, `fit`
+(`crop` or `clip`), `q`, `fm` (`jpg`/`png`/`webp`/`avif`), `auto=format`,
+`dpr`. `sharp` (libvips) does the work; transformed bytes are cached
+on disk by `(ref_key, params_hash)`.
+
+```
+/assets/<ref_key>?w=800&fit=crop&auto=format
+/assets/<ref_key>?w=400&h=400&fit=crop&fm=webp
+```
+
+The SDKs build these for you:
+
+```ts
+client.assetUrl(refKeyOrId, { w: 800, fm: 'webp', auto: 'format' });
+```
+
+### Backends
+
+Asset bytes go in one of two places:
+
+- **In the database** (default in dev): bytes live in an
+  `asset_blobs` table next to everything else. Backups are one
+  file. No filesystem to maintain.
+- **On disk**: a directory of files keyed by `ref_key`. Picks up a
+  CDN cleanly in front of `/assets/`.
+
+External-bucket adapters (S3, R2) are planned, not shipped — see
+[`roadmap.md`](./roadmap.md). The backend interface exists; the
+implementations don't.
+
+### Asset versions
+
+Same model as entries: every replacement creates a new version. The
+HTTP `GET /assets/:id` always serves the current `ref_key`'s bytes;
+direct `GET /assets/<old_ref_key>` keeps serving the historical
+bytes until a future cleanup phase (not yet automated).
+
+For the full asset model — uploads, transforms, in-place
+replacement, the cache — see [`assets.md`](./assets.md).
+
+---
+
+## Locales
+
+Multi-language content as a built-in. A type opts in by declaring
+`locales`; individual fields opt in with `localized: true`. The
+default-locale value lives at the top level of the entry's content;
+other locales go in a `_locale` sidecar keyed by locale code.
+
+```ts
+defineType('blog_post', {
+  title: field.string({ required: true, localized: true }),
+  body: field.markdown({ required: true, localized: true }),
+  slug: field.slug({ required: true, from: 'title' })
+}, {
+  locales: ['en', 'fr', 'es'],
+  default_locale: 'en',
+  fallback: { fr: 'en', es: 'en' }
+});
+```
+
+What an entry's content looks like in storage:
+
+```json
+{
+  "title": "Hello",
+  "body": "# Hi there",
+  "slug": "hello",
+  "_locale": {
+    "fr": { "title": "Bonjour", "body": "# Salut" },
+    "es": { "title": "Hola" }
+  }
+}
+```
+
+On read, pass `?locale=fr` (HTTP) or `{ locale: 'fr' }` (SDK). ledric
+merges the right values onto the top-level shape, walking the
+`fallback` chain when a translation is missing for the requested
+locale. Spanish here would resolve `body` from `en` because `es` is
+missing it and `es → en` in the fallback chain.
+
+Slugs can be locale-specific too — a French post can have `bonjour`
+where the English one has `hello`. Every locale's slug lives in
+`slug_history` separately.
+
+For the full localization story — locale-specific slugs, fallback
+chains, recipes — see [`localization.md`](./localization.md).
+
+---
+
+## Environments
+
+The storage schema reserves environment columns (`env_id`,
+`parent_env`) on every type, entry, and asset row. Originally this
+was to support full-environment branching: fork "production" into
+"staging", edit, merge back.
+
+**Today the API to fork, edit, and merge environments isn't
+exposed.** Every read and write happens in the default environment.
+You can't ask ledric for "what would change if I merged staging
+into production" because there's no `staging`.
+
+If you need staged content right now: use the draft / publish
+distinction. Drafts don't appear in published reads. That's a much
+narrower mechanism than environment branching, but it covers the
+"work-in-progress that shouldn't go live yet" case for most
+content workflows.
+
+Branching is on the post-v1 roadmap. See [`roadmap.md`](./roadmap.md).
+
+---
+
+## The wire format
+
+One last thing worth internalising: an entry on the wire is **flat**.
+
+```json
+{
+  "id": "018f2d40-2b18-7d92-9cf1-1b2934a7e9b3",
+  "slug": "hello-world",
+  "type": "blog_post",
+  "version": 4,
+  "fields": {
+    "title": "Hello, world",
+    "slug": "hello-world",
+    "body": "# Hello\n\nFirst post.",
+    "hero": "019dc0b5553477e894374b563cd4e633",
+    "author": [{ "type": "author", "slug": "j" }],
+    "tags": ["greetings"]
+  }
+}
+```
+
+Compare to Contentful, where every field is wrapped in a locale
+envelope and the entire response sits inside a `sys` / `fields` /
+`metadata` envelope of its own. ledric responses don't carry that
+overhead by default. There's an optional `_meta` block (version,
+schema_version, content_hash, request_id) that you can opt into per
+call with `include_meta: true`, but it's off by default.
+
+This matters mostly because of how LLMs read and write content.
+Token cost on a list of 20 entries is the field bytes, not the
+field bytes plus 20 envelopes' worth of structural noise. The model
+can pattern-match the shape after one example.
+
+For the full response shape — `_redirect` sidecar, `_locale`,
+`_refs` from `resolveRefs: true`, expanded assets — see
+[`http-api.md`](./http-api.md).
+
+---
+
+## Where to go next
+
+- [Build a site with an agent](./build-with-an-agent.md) — what these
+  concepts feel like in practice, end to end.
+- [Schema](./schema.md) — the field-type catalogue and validation rules.
+- [MCP tools](./mcp-tools.md) — the tool surface that operates on
+  everything above.
+- [HTTP API](./http-api.md) — the same surface over plain HTTP, plus
+  every query parameter.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,320 @@
+# FAQ
+
+The questions that come up most. Three to six sentences each, with a
+link to the deeper doc when there is one.
+
+- [Status & maturity](#status--maturity)
+- [Storage & scaling](#storage--scaling)
+- [Architecture](#architecture)
+- [Comparisons](#comparisons)
+- [Editor UX](#editor-ux)
+- [Hosting & deployment](#hosting--deployment)
+- [The agent / MCP angle](#the-agent--mcp-angle)
+- [Migrating in](#migrating-in)
+- [Backups & operations](#backups--operations)
+
+---
+
+## Status & maturity
+
+### Is this production-ready?
+
+Not yet. ledric is alpha. The core works end-to-end (schema, entries,
+assets, versions, MCP, HTTP, admin GUI, inline editor), and there's a
+unit-test suite of around 360 tests plus a Playwright smoke suite,
+but it has not been run in production by anyone other than the
+author. Expect shape changes before v1. If you try it on something
+real, please open an issue when something breaks.
+
+### What's "alpha" actually mean here?
+
+Specifically: APIs may change, error codes may rename, the storage
+schema may add columns (with migrations, but still). The features
+listed in the README under "What you get" are real and tested; the
+items under "What's planned" are not. See
+[`roadmap.md`](./roadmap.md).
+
+### Why was so much of this written by AI?
+
+Because the author is one person and AI is in fact good at typing.
+The design decisions are human; the keystrokes are mostly not. The
+practical consequence is that the surface area is bigger than one
+human could reasonably have hand-written in the time available, and
+the test suite is the safety net. If you find a bug that smells like
+"the model didn't understand the spec here", that's probably
+exactly what happened — please file it.
+
+---
+
+## Storage & scaling
+
+### Why SQLite by default?
+
+Because most content sites are smaller than people think, and
+SQLite is the lowest-friction way to ship a CMS. One file. No
+separate database process to manage. `cp ledric.db backup.db` is a
+backup. `scp` is a deploy. Nothing to install on a fresh VM
+beyond Node. You can graduate to Postgres or MySQL when SQLite
+genuinely runs out of room — the storage layer is portable.
+
+### Can SQLite handle real traffic?
+
+Read-heavy workloads, yes — comfortably. SQLite at WAL mode
+handles thousands of concurrent reads on a single machine. The
+sharp limit is *concurrent writes*: SQLite serialises writes
+through a single writer. For a CMS that's almost never a
+problem (humans and agents don't write content at machine
+speeds). Read-heavy traffic in front of `/assets/<ref_key>` is
+also normally CDN-cached, which moves the busiest URLs out of
+ledric's hot path entirely. If you're writing thousands of
+entries per second, you want Postgres.
+
+### When should I switch to Postgres or MySQL?
+
+Switch when you have a concrete reason: multiple writer processes,
+read replicas, a managed-database operational story you already
+trust, or vector / FTS workloads that benefit from
+production-grade engines. Don't switch because someone said
+"SQLite isn't a real database" — that hasn't been true for a
+decade. See
+[`deployment.md`'s Postgres / MySQL section](./deployment.md#postgres--mysql-deploys).
+
+### How big can my content get on SQLite?
+
+The practical ceiling is "as much as fits comfortably on the
+disk and the page cache". A few GB of structured content
+(thousands of entries) is well inside the comfort zone. Asset
+*bytes* in the DB grow faster than entry rows do; if you're
+storing many large originals, switching to the local
+filesystem backend (or an external bucket once those land —
+see [`roadmap.md`](./roadmap.md)) is a more meaningful
+optimisation than switching engines.
+
+---
+
+## Architecture
+
+### Is there a plugin system?
+
+No. The core is fixed: storage adapters, schema engine, MCP, HTTP,
+admin GUI, asset pipeline. Customisation lives in the layer above
+ledric — your consumer site, an `@ledric/proxy` mounted in front,
+or your own scripts hitting the HTTP API. If you find yourself
+reaching for a plugin hook, please file an issue describing the
+shape; that's useful information for the v1 design.
+
+### What's `@ledric/proxy`?
+
+A server-side primitive for any Node-compatible framework
+(Astro, Next.js, Express, Hono, etc.). It mounts at a path on
+your consumer site, holds the admin API key server-side, and
+forwards a curated subset of ledric's HTTP surface to the
+browser. Use it when the inline editor needs admin reach
+(versioned reads, asset uploads) but you don't want to leak the
+admin key into client code.
+
+### Why is the consumer site a separate process?
+
+Because the consumer doesn't need ledric's dependencies.
+`better-sqlite3` and `sharp` (libvips) are ~50MB of native
+binaries each, and they don't belong in your Vercel build for a
+site that's only doing reads. The two-process shape also means
+ledric scales independently — your CMS box and your render
+boxes are different concerns. See the architecture section in
+[`build-with-an-agent.md`](./build-with-an-agent.md#architecture-ledric-and-your-consumer-site-are-separate-processes).
+
+### Can I run ledric and the consumer site in the same process for local dev?
+
+You can colocate them in two terminals (or one `concurrently`
+script) — that's the recommended local setup. You shouldn't
+import the `ledric` package into your consumer site's runtime
+code; the SDK (`@ledric/sdk`) is what consumer code should use.
+
+---
+
+## Comparisons
+
+### How does it compare to Payload? Sanity? Directus? Strapi?
+
+Long answer in [`why.md`](./why.md). The short version:
+
+- **Payload**: ledric is process-separated and framework-agnostic; Payload is Next.js-embedded.
+- **Sanity**: ledric is self-hosted single-file SQLite with markdown content; Sanity is hosted-first with Portable Text.
+- **Directus**: ledric owns its schema; Directus reads schema from your existing database.
+- **Strapi**: ledric has no plugin ecosystem and no admin-clicking schema builder; Strapi has both.
+
+Across all four, ledric leans harder on MCP-as-primary-interface,
+markdown-as-rich-content, and flat-token-cheap-responses than the
+others.
+
+---
+
+## Editor UX
+
+### Does the admin GUI work without an MCP client?
+
+Yes. The admin GUI is a regular SPA; load `http://localhost:3000/admin`
+in any browser, paste the admin key, and you can author content
+without ever touching MCP. MCP is a *second* interface, not a
+prerequisite.
+
+### Can a non-technical user use it without an LLM in the loop?
+
+Mostly yes, with caveats. Schema authoring (creating types, adding
+fields) requires either chat-with-an-agent or someone writing
+`defineType()` — there's no Content-Type Builder UI like Strapi's.
+Once types exist, day-to-day content authoring (writing entries,
+uploading assets, publishing, tagging) is fully covered by the
+admin GUI and the inline editor with no LLM involvement. The
+intended division of labour is "developer or agent sets up the
+schema; editor lives in the admin and inline editor".
+
+### What does the inline editor actually do?
+
+You drop one `<script>` tag on your rendered consumer site. It
+walks the DOM looking for `data-ledric-ref` and
+`data-ledric-field` attributes (the SDKs' `refAttrs()` helper
+emits these). When you hover an editable element, a pencil icon
+appears; click it, and a drawer slides in with the right form
+field already focused. Save → publish → the page reloads with
+new content. Full walkthrough in
+[`inline-editor.md`](./inline-editor.md).
+
+### Can I customise the admin GUI?
+
+Not at runtime — there's no theming or plugin system. You can
+fork it (it's React + Vite) but that's a real maintenance cost.
+The current direction is to keep the admin minimal and let
+non-trivial editorial UX live in your own consumer site, where
+the inline editor turns any rendered page into an editing
+surface.
+
+---
+
+## Hosting & deployment
+
+### Is there a hosted version planned?
+
+Not actively. The project is self-host-first by design and a
+hosted product would be a meaningful change in scope. If demand is
+high enough that someone offers managed hosting on top of the
+open-source core, that's fine — and the Apache-2.0 license
+permits it — but it's not on any roadmap right now.
+
+### Can I run it serverless / on Vercel?
+
+No, not directly. ledric uses `better-sqlite3` and `sharp` (both
+native modules) and runs as a long-lived process. Serverless
+runtimes (Vercel Functions, Cloudflare Workers, AWS Lambda) won't
+cleanly run that. The right shape is "long-running container
+or VM, behind a CDN that caches `/assets/<ref_key>`". Your
+*consumer site* can absolutely deploy to Vercel — it just calls
+ledric over HTTP. See [`deployment.md`](./deployment.md).
+
+### Can I put a CDN in front of ledric?
+
+You should. `/assets/<ref_key>` URLs are version-pinned, so
+they're long-lived-cacheable; the rest of the API is dynamic and
+should bypass the CDN cache. Sample CDN config notes are in
+[`deployment.md`](./deployment.md#asset-serving-via-a-cdn).
+
+### How do I run it behind TLS?
+
+Reverse proxy (Caddy, nginx, Traefik) doing TLS termination.
+ledric speaks plain HTTP and isn't trying to manage certs
+itself. See [`deployment.md`'s reverse-proxy
+section](./deployment.md#reverse-proxy--tls).
+
+---
+
+## The agent / MCP angle
+
+### What happens if MCP changes / Anthropic deprecates it?
+
+MCP is an open protocol with multiple implementations, not a
+proprietary Anthropic API. Even if Anthropic walked away from it
+tomorrow, the spec is published and the surface ledric exposes
+would still be reachable from any MCP-speaking client. More
+practically: every MCP tool ledric exposes is *also* reachable
+via plain HTTP at `POST /rpc`. If MCP died entirely, the same
+tool surface would still work over JSON-RPC-over-HTTP without
+any code changes on ledric's side. Loss-of-MCP would be
+unfortunate but not existential.
+
+### Do I have to use Claude?
+
+No. MCP is the protocol; Claude is one client. Cursor speaks
+MCP. Other agents are adding support. If you don't want any
+agent at all, the HTTP API and the admin GUI cover the entire
+surface — MCP is opt-in.
+
+### Does ledric send my content to Anthropic?
+
+No. ledric makes no outbound calls to any LLM provider. The
+agent runs in your environment (Claude Desktop, Claude Code,
+your own MCP client) and *that* client may send content to
+whichever LLM it's configured to use. ledric is purely a server;
+it serves whatever client knocks on its door.
+
+### Why are responses so flat compared to Contentful's?
+
+Because tokens cost money and context windows are finite. Every
+extra envelope key on every entry on every list response gets
+multiplied across every prompt the agent runs. The Contentful
+shape is fine for a renderer; it's expensive for an LLM. ledric
+opts the cost-saving way by default.
+
+---
+
+## Migrating in
+
+### How do I import from Contentful / Sanity / WordPress?
+
+There's no first-class importer in v1. The pattern that works
+today: write a small script (Python, Node, whatever you like)
+that reads from the source CMS's API, calls ledric's `create_type`
+to set up the schema, then loops through entries calling
+`draft` and `publish`. The scripts tend to be ~100-200 lines for a
+typical content set. Once the shape stabilises, first-class
+importers (Contentful first) are on the post-v1 roadmap.
+
+### Can I export my content out again?
+
+Yes. `GET /entries/<type>` and `GET /entries/<type>/<slug>`
+return JSON-everything. A small loop dumps your content to disk.
+The MCP `find` tool returns the same shape. There's no
+proprietary export format to lock you in — the wire format *is*
+the export format.
+
+---
+
+## Backups & operations
+
+### How do I back up my data?
+
+If you're on the default SQLite + in-DB-assets backend, your
+content is one file (`ledric.db`). Copy it. `cp`, `rsync`, `scp`,
+Restic, your-favorite-backup-tool — any of them work. Use SQLite's
+`.backup` command (or run a snapshot from a brief read lock) for
+a consistent copy under load. If you've moved assets to the
+on-disk backend, back up the assets directory alongside the DB.
+See [`deployment.md`'s backup section](./deployment.md#backups).
+
+### What about Postgres / MySQL?
+
+Standard database backups: `pg_dump` for Postgres, `mysqldump` for
+MySQL. Schedule it, store it somewhere with separate access
+control from the running database. Same as you'd do for any other
+service.
+
+### Where do I file bugs / get support?
+
+GitHub issues at <https://github.com/getledric/ledric/issues>.
+There's no paid support tier and no SLA — it's an alpha project.
+Reproducible bug reports get fixed faster than vague ones.
+
+### Is there a community?
+
+Small. GitHub Discussions, when enabled, is the place to ask
+"is this the right shape?" questions. For "I think this is a
+bug" — open an issue.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,292 @@
+# Roadmap
+
+What's stable, what's being worked on, what's planned, and what's
+explicitly not in scope. People plan around clear "no" better than
+around vague "maybe", so the lines below are deliberately drawn.
+
+No timeline commitments. ledric is a personal-project-scaled effort
+right now; "when it's ready" is the only honest answer.
+
+- [Stable](#stable)
+- [In progress](#in-progress)
+- [Planned (post-v1)](#planned-post-v1)
+- [Explicitly out of scope](#explicitly-out-of-scope)
+- [How decisions get made](#how-decisions-get-made)
+
+---
+
+## Stable
+
+APIs and behaviours that won't change before v1 without notice.
+"Stable" here means the surface; the implementation under it can
+still get better.
+
+- **The 20 MCP tools.** Names, argument shapes, and return shapes
+  are settled. New optional arguments may be added; existing ones
+  won't be renamed or repurposed without a deprecation cycle. See
+  [`mcp-tools.md`](./mcp-tools.md).
+- **The HTTP routes.** `GET /types`, `GET /entries/:type[/:slug]`,
+  `GET /assets/...`, `POST /assets`, `POST /rpc`. Same compatibility
+  promise.
+- **The wire format.** Flat entries with `fields`, optional
+  `_meta`, `_redirect` sidecar on slug renames, `_locale` sidecar
+  on localized reads, `_refs` sidecar on `resolveRefs: true`.
+- **Schema authoring.** `defineType()` from `@ledric/schema`,
+  the field-type catalogue documented in [`schema.md`](./schema.md),
+  the canonical JSON shape that gets stored.
+- **Auth model.** Two roles (admin, reader), `Authorization: Bearer`
+  header, env-var override. Closed-reads mode via
+  `--require-reader-key`.
+- **`@ledric/sdk` (TS) and `ledric/sdk` (PHP) public surfaces.**
+  The methods documented in [`sdks.md`](./sdks.md) are stable.
+  Internal helpers may move; public methods won't.
+- **`@ledric/proxy`.** The mount-anywhere proxy primitive's
+  public API.
+- **Slug history and redirects.** Renames retire old slugs into
+  `slug_history`; reads of old slugs return 301 with `_redirect`.
+- **Storage portability.** SQLite, Postgres, and MySQL are all
+  first-class. No plans to drop any of them.
+- **Asset URL shape.** `/assets/<ref_key>` with imgix-style
+  query parameters. URLs are version-pinned.
+
+---
+
+## In progress
+
+Partial features with concrete remaining work. These are real
+today in some form; they're not yet what they'll be at v1.
+
+### Stable test surface
+
+- **Unit tests** (~360 in vitest, SQLite-only by default;
+  ~18 Postgres + ~18 MySQL opt-in via env vars) cover storage,
+  schema, core, and MCP dispatch.
+- **Playwright e2e** smoke suite covers the admin GUI.
+- **Remaining:** more end-to-end coverage of HTTP routes against
+  real storage, a published "minimum supported Node" CI matrix.
+
+### Codegen
+
+- **Today:** `ledric types` reads your live schema and writes
+  `ledric.types.ts`. Optional `--augment-sdk` adds a
+  `declare module` block so `client.read<'blog_post'>(...)` is
+  inferred.
+- **Remaining:** more nuanced types for `:::ref{}:::` resolution
+  shape, generated guards (`isBlogPost(entry)`), better error
+  messages when the codegen runs against a stale schema.
+
+### Asset pipeline polish
+
+- **Today:** uploads, in-place bytes replacement, transforms via
+  sharp/libvips, two backends (db, local fs), URL version-pinning,
+  on-disk transform cache.
+- **Remaining:** automatic pruning of old `ref_key` bytes (today
+  they stick around forever), automatic cleanup of the transforms
+  cache, S3 / R2 / generic-bucket adapters (the backend interface
+  exists; the implementations don't).
+
+### MCP `init` and onboarding
+
+- **Today:** `ledric init` walks DB path, port, MCP client wiring
+  (Claude Desktop config, `.mcp.json` for Code/Cursor), key
+  minting, `.gitignore` patches.
+- **Remaining:** wider client support (anything new that joins the
+  MCP ecosystem), better recovery from partial-init states.
+
+---
+
+## Planned (post-v1)
+
+Real intentions, no commitments. Listed here so you know whether
+to wait or build around the gap.
+
+### `subscribe` / SSE / webhooks
+
+The original spec describes a `subscribe` MCP tool and a webhook
+delivery system. Neither is implemented. The delivery shape is
+clear; the work is real implementation effort plus deciding how
+the in-process bus on SQLite vs. native pub/sub on Postgres
+should differ.
+
+If you need eventing today, poll. The HTTP API is fast enough that
+a 5–30 second poll loop is fine for most "did anything change"
+workflows.
+
+### Versioning tools over MCP
+
+`read_version`, `revert`, `diff`, `list_versions` are described in
+the original spec but aren't surfaced as MCP tools. You can pass
+`version: N` to `read` today; the rest is HTTP-callable but not
+yet first-class.
+
+The shape is settled; this is mostly typing.
+
+### Branching and environments
+
+The storage schema has `env_id` and `parent_env` columns on every
+type, entry, and asset. The plumbing exists. The API to fork an
+environment, write changes inside it, and merge back into the
+parent doesn't.
+
+This is the feature that needs the most design work — copy-on-write
+metadata, three-way per-entry merge for JSON content, conflict
+representation that an agent can resolve programmatically. Not
+something to expect soon.
+
+### External asset backends
+
+S3 / R2 / generic-bucket adapters. The `AssetBackend` interface
+exists; the implementations don't. Mostly straightforward — the
+hard parts are auth, permissioning the upload path, and deciding
+how the backend interacts with version-pinned `ref_key` URLs.
+
+### Vector / similarity search
+
+The `vector` field type is wired through schema and validator —
+you can declare `field.vector({ dims: 1536, byo: true })` and
+write vectors to it. There is **no similarity-search query path
+yet**. `find` doesn't accept a `vector` filter. Don't ship a
+search-by-meaning feature on top of this today.
+
+When this lands, it'll likely use `pgvector` for Postgres,
+`sqlite-vec` (not vss) for SQLite, and a documented "your
+embedding model is your problem" stance for the actual vectors.
+
+### `:::component{…}:::` directives
+
+The original spec mentions `:::component{...}:::` as a sibling to
+`:::ref{...}:::` for rendering reusable components inline. The
+parser only recognises `:::ref{...}:::` today. Adding `component`
+is a small parser change plus a meaningful design decision: what
+does "a component" mean when the renderer is a separate process
+that ledric doesn't know about?
+
+The current answer is "use a `references` field that points at
+a section/component-shaped entry and let the renderer pick the
+template". `:::component{}:::` would only earn its place if it
+makes that flow noticeably nicer.
+
+### First-class importers
+
+Contentful, Sanity, Strapi, WordPress. Today's pattern is "write
+a small script". The pattern works; first-class importers are a
+nice-to-have, not a blocker for anyone determined.
+
+### Scheduled publishes
+
+`publish` is immediate today. Scheduled publish (move the
+`published_version` pointer at time T) is in the original spec
+and on the post-v1 list. Implementation needs a small worker /
+cron path to run.
+
+### Soft-delete retention policy
+
+Soft delete is implemented (`deleted_at` set, row stays).
+There's no automatic GC of soft-deleted rows yet — you have to
+hard-delete manually. Configurable per-type retention (default
+90 days, say) is on the post-v1 list.
+
+### Better admin GUI
+
+The admin works. It's deliberately functional. Nicer table
+filters, bulk operations, schema-editing UI for non-coders, an
+asset organiser that doesn't make you scroll forever — all of
+these are real opportunities, all on the post-v1 list. None of
+them are in flight today.
+
+### Permissions beyond admin / reader
+
+Per-type, per-field, per-environment grants. Two-role auth is
+fine for a small project; it isn't fine for an editorial team
+of 30 people with different responsibilities. This is on the
+post-v1 list and will probably need someone with strong
+opinions about CMS permission models to drive the design.
+
+---
+
+## Explicitly out of scope
+
+Lifted from the original spec, with caveats. These are decisions,
+not gaps.
+
+### Server-side LLM calls
+
+ledric makes no outbound calls to any LLM provider. No
+auto-alt-text, no NL→query translation inside the server, no AI
+translation, no embedding-on-write. Embedding is BYO — the
+client writes the vector — and everything else that wants AI
+involvement happens in the agent that's *talking* to ledric, not
+inside ledric itself.
+
+This boundary is intentional. It keeps ledric runnable on a
+laptop with no API keys, makes the security/privacy story
+straightforward (your content does not leave your machine
+unless you send it somewhere), and avoids the "but which model"
+political problem of building an LLM integration into the
+server.
+
+### Real-time collaborative editing
+
+No multiplayer cursors, no operational-transform document
+sync. The inline editor is a single-user click-to-edit drawer.
+Sanity Studio is genuinely good at multiplayer; if that's a
+hard requirement, that's the tool.
+
+### Portable Text
+
+Sanity's block-array rich-text format. Markdown plus
+`:::ref{}:::` directives covers the same ground with a more
+LLM-legible wire format and ledric leans on that. There is no
+plan to add Portable Text as a parallel field type.
+
+### Editor UI as a product
+
+The admin GUI exists; it isn't a separately-marketed product
+or a separately-themable surface. The expectation is that
+serious editorial UX lives on the consumer site, where the
+inline editor turns any rendered page into an editing surface.
+
+### Per-entry branching
+
+Full-environment branching is on the post-v1 list. Per-entry
+branching ("this one entry has a separate experimental branch
+nobody else can see") isn't planned. The version history per
+entry covers most of the same use cases more simply.
+
+### Hosted ledric
+
+Self-hosted only by design. If demand drives someone to offer
+managed hosting on top of the open-source core, that's fine
+(Apache-2.0 permits it), but it's not on any roadmap.
+
+---
+
+## How decisions get made
+
+Roughly:
+
+1. **Spec drift is reconciled toward the code.** When the
+   [original spec](./internal/original-spec.md) and the
+   shipping behaviour diverge, the docs reflect what ships. The
+   spec is preserved as a record of intent, not a
+   forward-looking promise.
+2. **GitHub issues and Discussions are the input channel.**
+   "I tried X and it broke" issues get fixed faster than design
+   debates, but design debates are read.
+3. **No private roadmap meetings.** If something's coming, it's
+   either listed above or being discussed in the open.
+
+If you want to influence what lands first: file the issue with
+the most concrete reproducer or use case. Concrete beats abstract
+every time.
+
+---
+
+## Where to go next
+
+- [Concepts](./concepts.md) — what's in the model today.
+- [FAQ](./faq.md) — the questions this page sets up.
+- [Why ledric](./why.md) — the comparative argument and "when
+  ledric is the wrong choice".
+- [Original spec](./internal/original-spec.md) — what was
+  intended; useful as historical context.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -15,6 +15,10 @@ This page covers:
 - [Validation](#validation)
 - [Evolving a schema](#evolving-a-schema)
 
+If "type", "entry", "slug", "ref", "version" don't already mean
+something specific to you, [`concepts.md`](./concepts.md) is the
+primer this page assumes.
+
 For agent prompts that walk Claude through schema setup, see
 [`agent-recipes.md`](./agent-recipes.md).
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -1,0 +1,291 @@
+# Why ledric
+
+There are already plenty of headless CMSes. This page is the honest
+case for ledric being a different shape, plus the equally honest case
+for when it isn't the right tool.
+
+The TL;DR: most CMSes were designed for a person clicking around in a
+web app, with the API as a side effect. ledric is designed for an
+agent driving the API, with a person's admin GUI as a side effect.
+Most of the differences below trace back to that.
+
+- [The shape of the bet](#the-shape-of-the-bet)
+- [vs Contentful](#vs-contentful)
+- [vs Sanity](#vs-sanity)
+- [vs Payload](#vs-payload)
+- [vs Strapi](#vs-strapi)
+- [vs Directus](#vs-directus)
+- [When ledric is the wrong choice](#when-ledric-is-the-wrong-choice)
+
+---
+
+## The shape of the bet
+
+Three constraints ledric doesn't break:
+
+1. **Tokens are the new bandwidth.** Every default — response shape,
+   list budgets, schema serialisation — is tuned for minimal
+   agent-side overhead.
+2. **Agents edit differently than humans.** They batch. They diff.
+   They need optimistic concurrency, structured errors, and
+   dry-runs. The tool surface is shaped for both.
+3. **The schema is the API.** `describe_model` returns the entire
+   content model in a single call. There is no second source of
+   truth for an agent to keep in sync.
+
+Everything else in this project is a downstream consequence.
+
+---
+
+## vs Contentful
+
+Contentful is the archetype of "headless CMS that predates
+agent-driven workflows". Solid for what it was designed for. Painful
+when you put an LLM in front of it.
+
+| Contentful pain | ledric fix |
+|---|---|
+| Every node wrapped in `{ sys, fields, metadata }`. A "give me 20 posts" call is half envelope. | Flat entries. `_meta` only when explicitly requested with `include_meta: true`. |
+| Rich text is a proprietary JSON tree (Contentful's "Rich Text format"). One SDK can render it. LLMs can't read or write it usefully. | `markdown` field type. The wire format is the string. Diff it in git, paste it in Slack, render it with anything. |
+| Fields are always wrapped in a per-locale envelope (`{ "en-US": "value" }`), even for unlocalized content. | Default locale lives at the top level. `_locale` sidecar only when the type opts in. |
+| GraphQL surface encourages nested queries → N+1 reads, token bloat. | Flat reads with `expandAssets` and `resolveRefs` opt-ins. You ask for what you want, you get only that. |
+| Content model changes are made in the web UI; "migrations as code" is a bolted-on contrib library. | Schema-as-code via `defineType()`, or `create_type`/`alter_type` over MCP. Same canonical row either way. |
+| Environments take seconds to spin up; merging is manual. | Single environment in v1; copy-on-write branching is on the roadmap. (Honest gap, not a strength.) |
+| MCP support is an afterthought (community projects, not first-party). | MCP is the primary interface. Twenty tools, designed against the data model. |
+| Self-hosting requires a paid enterprise plan. | Self-hosting is the only deployment model. |
+
+The Contentful comparison is the most lopsided of the bunch — they're
+solving for a different shape of customer, and there's no overlap on
+"agent-first design".
+
+When Contentful is still the right choice: large editorial teams that
+need fine-grained role-based access today, multi-region SOC2-attested
+hosting, an editor experience that's been polished for a decade, or
+integrations with adjacent SaaS that ledric doesn't have (and won't
+soon).
+
+---
+
+## vs Sanity
+
+Sanity is the closest thing to a "developer-first" CMS that
+predates LLM tooling. Schema-as-code (TypeScript), real-time
+collaborative editing in Sanity Studio, Portable Text for rich
+content, hosted by default with an optional self-host path.
+
+What ledric does differently:
+
+- **Markdown, not Portable Text.** Portable Text is a
+  block-array JSON format. It's well-defined, and it's what
+  Sanity has always recommended. It's also poorly suited to an
+  LLM editing a document — every paragraph is a JSON object, every
+  inline mark is a span object. ledric uses markdown strings with
+  `:::ref{…}:::` directives for cross-content embedding. The
+  diffing, copy-pasting, and prompt-shaping ergonomics are
+  qualitatively different.
+- **Local SQLite by default.** Sanity is hosted-first; you store
+  content in their cloud (or self-host the dataset, but the studio
+  expects to talk to the hosted service). ledric is single-process,
+  one file, runs on a laptop or a $5 VPS. Postgres / MySQL when you
+  outgrow that.
+- **MCP as the primary interface.** Sanity has a community MCP
+  server; ledric's tool surface was designed against the data
+  model from day one.
+- **No real-time collaborative editing.** Sanity Studio's
+  multiplayer cursor experience is genuinely good. ledric doesn't
+  have it. The inline editor is a single-user click-to-edit
+  drawer.
+
+When Sanity is still the right choice: a team that's already been
+using Sanity Studio happily, real-time collaborative editing as a
+hard requirement, a content workflow that maps cleanly onto Portable
+Text, willingness to pay for the hosted product.
+
+---
+
+## vs Payload
+
+Payload (now Payload 3.0) is "developer-first CMS as a Next.js
+plugin". You install it into your Next app, it provides an admin
+panel and a database layer, you ship one process.
+
+What ledric does differently:
+
+- **Separate process by design.** ledric runs in its own directory,
+  exposing HTTP. Your consumer site is a different project that
+  fetches over the network — same shape whether the consumer is
+  Next.js, Astro, plain PHP, or a static-site builder. Your ledric
+  process doesn't drag `sharp` and `better-sqlite3` (~50MB native
+  binaries) into every consumer build.
+- **MCP-first.** Payload has REST + GraphQL + a Local API for
+  same-process callers. ledric has MCP + a flat HTTP `POST /rpc`
+  that mirrors the MCP surface. An agent gets the same tool
+  catalogue regardless of transport.
+- **No framework lock-in.** Payload is heavily integrated with
+  Next.js — that's the value proposition for some teams and a
+  blocker for others. ledric doesn't care what your renderer
+  uses.
+- **Code-first schema, not config-driven.** Payload's schema is
+  a config object you pass to `payload.init()`; ledric's is a
+  `defineType()` call that emits canonical JSON, callable from
+  TypeScript or chat (via `create_type`). The end state is the
+  same row in the DB.
+
+When Payload is still the right choice: you want a CMS embedded in
+your Next.js app, you want fine-grained access control out of the
+box, you want a more polished admin UI, and you're happy living
+inside the Next ecosystem.
+
+---
+
+## vs Strapi
+
+Strapi is the longest-running open-source headless CMS. Big plugin
+ecosystem, optional self-host, a Node + database stack.
+
+What ledric does differently:
+
+- **No plugin system (yet).** Strapi's plugin architecture is its
+  selling point and its accumulated complexity. ledric ships a
+  fixed core: storage adapters, the asset pipeline, the schema
+  engine, MCP, the admin GUI. If you want to customise behaviour,
+  you write a thin layer on top — there's no extension API to
+  learn.
+- **Schema-as-code, not admin-clicking.** Strapi's primary schema
+  authoring is the Content-Type Builder (a UI). ledric's primary
+  authoring is `defineType()` or chat. Both produce the same
+  canonical row.
+- **Single-file SQLite default.** Strapi can run on SQLite; the
+  documentation pushes you toward Postgres + a separate hosting
+  setup for anything serious. ledric makes the SQLite-file path
+  the default and stays there.
+- **MCP-first.** Strapi has a community MCP plugin. ledric's tool
+  surface is the primary interface.
+- **Token-cheap responses.** Strapi's REST responses include
+  Strapi's own envelope (`{ data, meta, attributes: {...} }`).
+  ledric's are flat.
+
+When Strapi is still the right choice: you want a vast plugin
+catalogue, you want an admin UI that's been iterated on for years,
+you want roles + permissions out of the box, and the agent-first
+design is a non-goal.
+
+---
+
+## vs Directus
+
+Directus is "an instant API on top of any SQL database". Point it at
+your existing Postgres, get REST and GraphQL.
+
+What ledric does differently:
+
+- **ledric owns its schema.** Directus reads schema from your
+  database. ledric writes schema *to* its database, validated and
+  versioned by the type system. The two products are solving
+  different problems — Directus says "I'll API-ify what you've
+  already got"; ledric says "let me model your content".
+- **Schema versioning and migration tooling.** Every entry is
+  written under a known schema version; `alter_type` classifies
+  changes; `migrate_entries` re-validates and backfills. Directus
+  doesn't really have an equivalent — schema changes are SQL
+  migrations on your database.
+- **MCP-first.** Directus has community MCP work; ledric is
+  primary.
+- **Flat wire format.** Directus's responses include relational
+  metadata Directus needs, which an agent has to parse around.
+
+When Directus is still the right choice: you have an existing SQL
+database that's already shaped the way you want, you want generic
+data tooling more than a CMS, or your team is more comfortable
+with SQL than with code-first schemas.
+
+---
+
+## When ledric is the wrong choice
+
+This is the section that makes the rest of the page credible.
+ledric is alpha and opinionated. It's not the right pick for
+several real situations.
+
+### You need fine-grained role-based access today
+
+ledric ships two roles: admin (writes) and reader (reads).
+Per-type, per-field, per-environment grants are not implemented.
+If your content workflow needs "writers can edit drafts but only
+editors can publish, and only certain editors can touch the
+homepage", ledric isn't there yet — and probably won't be for a
+while. Contentful, Sanity, and Strapi all do this better today.
+
+### You need real-time collaborative editing
+
+Two people simultaneously editing the same blog post with cursors
+and presence indicators? That's not in scope. Sanity Studio is
+genuinely good at this; if it matters to your team, that's the
+tool.
+
+### You need SOC2-attested managed hosting
+
+ledric is self-hosted, alpha-grade, and has had no audit. If
+you're shipping to a regulated environment that requires
+attestation today, the conversation is over before it starts. A
+hosted offering is on the very speculative future roadmap; right
+now there isn't one.
+
+### You need a polished editor UX out of the box
+
+The admin GUI works. It's deliberately functional, not delightful.
+Field forms render from the schema, the entry list is a table, the
+asset library is a grid. If your editorial team expects the
+inline-rich-text-with-AI-helpers experience that's now table
+stakes in commercial CMSes, ledric will feel sparse.
+
+The inline-on-page editor is genuinely differentiated and worth
+trying — but it's a single-user, click-to-edit drawer, not a
+collaborative writing surface.
+
+### You need a serverless / edge deployment
+
+ledric runs as a long-lived Node process. It uses
+`better-sqlite3` and `sharp` (libvips), both of which are
+native modules incompatible with most serverless runtimes
+(Vercel Functions, Cloudflare Workers, etc.). The right shape is
+"long-running container or VM behind a CDN" — see
+[`deployment.md`](./deployment.md). If "no servers" is a hard
+requirement, this isn't the tool.
+
+### You need to point a CMS at an existing database
+
+ledric writes its own tables (`types`, `entries`, `entry_versions`,
+`assets`, etc.) into the database you give it. It doesn't read or
+expose tables you've already created — that's Directus's job, not
+ledric's.
+
+### You need a plugin / extension ecosystem
+
+ledric has neither. The fixed core is intentional. If your stack
+depends on a CMS that has plugins for your specific CRM, your
+specific newsletter, your specific commerce platform, ledric will
+not have any of those — and the work to add them is on you.
+
+### You need vector / semantic search today
+
+The `vector` field type is wired through the schema and validator,
+but there's no similarity-search query path yet. Don't ship a
+production search-by-meaning feature on top of it.
+
+### You need stability
+
+It's alpha. Shapes will shift before v1. AI did most of the
+typing. If "the API contract has been frozen for two years and
+won't move" is a value to you, this isn't it yet.
+
+---
+
+## Where to go next
+
+- [Concepts](./concepts.md) — the mental model behind everything above.
+- [Build a site with an agent](./build-with-an-agent.md) — what
+  ledric feels like end-to-end.
+- [Roadmap](./roadmap.md) — what's stable, what's in progress, what's
+  out of scope.
+- [FAQ](./faq.md) — the more specific questions this page sets up.


### PR DESCRIPTION
## Summary

Six new docs pages and a cross-link pass.

- **`docs/concepts.md`** — the mental model in one page: types, entries, ids vs slugs vs refs, versions, structural vs inline references, assets, locales, environments, and the wire format. Reconciled against shipping behaviour, not the original spec — so `read_version`/`revert`/`diff` over MCP are flagged as not-yet-shipped, branching is described as reserved-only, vector field is called out as a stub.
- **`docs/why.md`** — comparisons vs Contentful, Sanity, Payload, Strapi, Directus. Plus an honest "When ledric is the wrong choice" section covering RBAC, real-time collaboration, SOC2 hosting, polished editor UX, serverless deploys, plugin ecosystems, vector search, and stability.
- **`docs/faq.md`** — Q&A on production-readiness, SQLite limits, Postgres/MySQL switchover, plugins, comparisons, serverless, admin GUI without MCP, MCP/Anthropic risk, backups, and importing from other CMSes.
- **`docs/architecture.md`** — what's running when `ledric serve --gui` boots: package layout, the three-dialect storage adapter, the asset pipeline (sharp/libvips, transform cache, db vs local backends), the inline editor's three-piece flow, the two-process consumer pattern, and process lifecycle.
- **`docs/roadmap.md`** — stable / in-progress / planned (post-v1) / explicitly out of scope. Concrete callouts for the gaps surfaced during the codebase survey: subscribe/SSE/webhooks, version tools over MCP, branching, external asset backends, vector search, soft-delete retention, scheduled publishes, RBAC.
- **`docs/build-with-an-agent-php.md`** — PHP counterpart walkthrough mirroring the Astro version. Vanilla PHP + `ledric/sdk` + `league/commonmark`, PHP's built-in dev server, `LedricClient::refAttrsHtml()` for inline-editor wiring. Honestly notes that there's no committed `examples/blog-php/` artifact yet (existing `examples/blog/` is HTML+JS) — open issue to commit one is implicit.
- **Cross-link pass** — `concepts.md` linked from `schema.md` and `build-with-an-agent.md` intros; README docs index reordered (concepts → walkthroughs → schema → reference → ops → comparative) with rows for the 6 new pages.

Tone matched to existing `schema.md` / `build-with-an-agent.md`. Every aspirational claim either ships today or sits in `roadmap.md` / "When ledric is the wrong choice" with an honest caveat.

## Verification

- All 94 internal file links resolve (verified with a script).
- All anchor links resolve against GitHub's slug rules (verified with the same script).
- Codebase survey done before writing — every shipped-today claim is grounded in a `file:line`; every gap is called out explicitly.

## Test plan

- [ ] Read `docs/concepts.md` end-to-end and confirm tone + accuracy
- [ ] Read `docs/why.md` and confirm the "when ledric is wrong" section is honest enough
- [ ] Spot-check `docs/faq.md` answers against the README's claims
- [ ] Read `docs/architecture.md` against the actual package layout in `packages/`
- [ ] Read `docs/roadmap.md` and confirm nothing in "Stable" is actually unstable
- [ ] Read `docs/build-with-an-agent-php.md` and decide whether to commit a runnable `examples/blog-php/` artifact (and open the issue)
- [ ] Eyeball the README docs index ordering
- [ ] Verify the anchor links from `schema.md` and `build-with-an-agent.md` to `concepts.md` render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)