### PR TITLE
fix: restore listClients/revokeClient exports for the CLI (0.3.1)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ledric",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ledric CLI — single-binary entry point.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -50,7 +50,7 @@ export const DEFAULTS: InitAnswers = {
 // Version pin for the @ledric/proxy dep we add to a consumer's
 // package.json. Kept in lockstep with the CLI's own version — bump on
 // each release that ships a proxy change.
-export const PROXY_DEP_VERSION = '^0.3.0';
+export const PROXY_DEP_VERSION = '^0.3.1';
 
 const LEDRIC_GITIGNORE_LINES: readonly string[] = [
   '# ledric',

--- a/packages/cli/src/commands/oauth.ts
+++ b/packages/cli/src/commands/oauth.ts
@@ -14,36 +14,25 @@ const clientsListCommand = defineCommand({
     description: 'List OAuth clients registered against this ledric.'
   },
   args: {
-    db: dbArg,
-    'include-revoked': {
-      type: 'boolean',
-      description: 'Include revoked clients in the listing.',
-      default: false
-    }
+    db: dbArg
   },
   async run({ args }) {
     const storage = await openSqlite({ path: resolveDb(args.db) });
     try {
-      const clients = await listClients(storage, {
-        includeRevoked: args['include-revoked'] === true
-      });
+      const clients = await listClients(storage);
       if (clients.length === 0) {
         process.stderr.write('No OAuth clients registered.\n');
         return;
       }
-      // Two-line entry per client. The DCR-supplied name is shown in
-      // quotes and labelled "claimed" — operators have stared at this
-      // string before approving consent, so the framing has to make
-      // its trust level obvious.
+      // The DCR-supplied name is shown in quotes and labelled "claimed" —
+      // operators have stared at this string before approving consent, so
+      // the framing has to make its trust level obvious.
       for (const c of clients) {
-        const status = c.revoked_at !== null
-          ? ` (revoked ${new Date(c.revoked_at).toISOString()})`
-          : '';
         process.stdout.write(
-          `${c.client_id}${status}\n` +
+          `${c.client_id}\n` +
             `  claimed name: "${c.name}"\n` +
             `  redirect_uris: ${c.redirect_uris.join(', ')}\n` +
-            `  registered: ${new Date(c.created_at).toISOString()}\n\n`
+            `  grant_types: ${c.grant_types.join(', ')}\n\n`
         );
       }
     } finally {
@@ -73,7 +62,7 @@ const clientsRevokeCommand = defineCommand({
         process.stderr.write(`Revoked OAuth client ${args.client_id}\n`);
       } else {
         process.stderr.write(
-          `No active OAuth client with id ${args.client_id} (already revoked or never existed).\n`
+          `No OAuth client with id ${args.client_id} (already revoked or never existed).\n`
         );
         process.exit(1);
       }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ledric core: schema engine, versioning, refs, validation, ACL. DB-agnostic.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/gui",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ledric admin GUI — React via CDN, served by @ledric/http-server.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/http-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ledric HTTP server: tool-shaped POST /rpc + REST GET projections, built on Fastify, binding @ledric/core.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/mcp-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ledric MCP server: MCP tool surface bound to @ledric/core (stdio + HTTP+SSE).",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/oauth",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "OAuth 2.1 provider for ledric — DCR + auth code + PKCE + JWT/JWKS, single-process, no external IdP. Mounted by @ledric/http-server when mcp.public is on.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/oauth/src/clients.ts
+++ b/packages/oauth/src/clients.ts
@@ -1,0 +1,41 @@
+import type { LedricStorage } from '@ledric/storage';
+
+export interface ClientSummary {
+  client_id: string;
+  name: string;
+  redirect_uris: string[];
+  grant_types: string[];
+}
+
+function asStringArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+}
+
+export async function listClients(storage: LedricStorage): Promise<ClientSummary[]> {
+  const rows = await storage.db
+    .selectFrom('oidc_payloads')
+    .select(['id', 'payload'])
+    .where('model', '=', 'Client')
+    .execute();
+  return rows.map((r) => {
+    const p = JSON.parse(r.payload) as Record<string, unknown>;
+    return {
+      client_id: r.id,
+      name: typeof p.client_name === 'string' ? p.client_name : '',
+      redirect_uris: asStringArray(p.redirect_uris),
+      grant_types: asStringArray(p.grant_types)
+    };
+  });
+}
+
+export async function revokeClient(
+  storage: LedricStorage,
+  clientId: string
+): Promise<boolean> {
+  const result = await storage.db
+    .deleteFrom('oidc_payloads')
+    .where('model', '=', 'Client')
+    .where('id', '=', clientId)
+    .executeTakeFirst();
+  return Number(result.numDeletedRows ?? 0) > 0;
+}

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -5,3 +5,6 @@ export { SCOPE_TO_ROLE } from './types.js';
 
 export type { BuildProviderOptions } from './provider.js';
 export { buildProvider, KyselyOidcAdapter, reapExpiredOidcPayloads } from './provider.js';
+
+export type { ClientSummary } from './clients.js';
+export { listClients, revokeClient } from './clients.js';

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/proxy",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Server-side proxy primitive for ledric — keeps the browser off the ledric origin and keys off the client. Framework-agnostic (Request) => Promise<Response> handlers.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/schema",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ledric schema definition helpers: defineType, field.*, JSON emit, Zod codegen.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ledric vanilla TypeScript read client SDK.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/storage",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ledric storage: Kysely-based dialect adapters. SQLite (better-sqlite3) default; MySQL and Postgres also supported.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

The oidc-provider swap in #15 deleted the hand-rolled Client store but left `packages/cli/src/commands/oauth.ts` importing `listClients` and `revokeClient` from `@ledric/oauth`. Published 0.3.0 crashes at CLI module load:

```
SyntaxError: The requested module '@ledric/oauth' does not provide an export named 'listClients'
```

This re-adds the two helpers as thin queries against the new `oidc_payloads` table (`model='Client'`), and slims the `ledric oauth clients` subcommand to match the new model — `revoked_at` / `created_at` / `--include-revoked` no longer apply (clients are hard-deleted, no creation timestamp is stored).

All packages bumped to **0.3.1** and `PROXY_DEP_VERSION` follows.

## Why this slipped through CI

- **`pnpm build` doesn't resolve workspace imports.** tsup/esbuild emits the named imports verbatim and treats `@ledric/oauth` as external — it never checks whether `listClients` actually exists on the target. ESM's named-import verification only runs at load time, when an end-user actually executes the binary.
- **`pnpm typecheck` *would* have caught it** (TS2305) — but only against the current `packages/oauth/dist/index.d.ts`. With `workspace:*` deps, tsc reads via the symlink, so a stale local dist (from a previous build with the old API) silently masked the error. Confirmed: a fresh full build + typecheck now reports it cleanly.
- **No test imports `oauth.ts`.** CLI subcommands dispatch lazily through citty's map; vitest only loads modules its tests touch, so the broken top-level import was never evaluated.

A `node packages/cli/dist/cli.js --help` smoke step in CI would catch this class of bug in milliseconds.

## Test plan

- [x] `pnpm test` — 426 passed, 18 skipped (sqlite)
- [x] `pnpm typecheck` — oauth errors gone (4 pre-existing errors elsewhere, unrelated)
- [x] `pnpm build` — clean
- [ ] Verify post-publish: `npx ledric@0.3.1 -y` on a fresh dir loads without the SyntaxError

🤖 Generated with [Claude Code](https://claude.com/claude-code)