### PR TITLE
chore(cli): smoke-load the built binary in prepack

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,8 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "clean": "rm -rf dist",
-    "prepack": "tsup"
+    "smoke": "node dist/cli.js --help > /dev/null && node dist/cli.js init --help > /dev/null",
+    "prepack": "tsup && pnpm smoke"
   },
   "dependencies": {
     "@clack/prompts": "^1.3.0",


### PR DESCRIPTION
## Summary

Adds a `smoke` script to the CLI package that runs `node dist/cli.js --help` and `node dist/cli.js init --help` against the freshly-built binary, and chains it into `prepack`. If the built artifact fails to module-load, `pnpm publish` aborts before the broken tarball reaches the registry.

This is the gap that let 0.3.0 ship with broken named imports from `@ledric/oauth` (#16) — tsup/esbuild emits the imports verbatim without resolving the target, vitest never loads the binary as a subprocess, and stale local `dist/` types masked the typecheck error.

## Verification

Verified locally that the smoke script catches the regression class:

- Restored the `listClients` export → `pnpm --filter ledric smoke` exits 0
- Removed the export and rebuilt → smoke script crashes with the exact `SyntaxError: The requested module '@ledric/oauth' does not provide an export named 'listClients'` end-users hit, exit 1, which would abort the publish chain

## Test plan

- [x] Baseline smoke passes against current dist
- [x] Reproduced + verified failure mode under the missing-export regression
- [x] `pnpm test` — 426 passing (no test changes, just a build-script change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)