### PR TITLE
fix(http-server): forward mcp/cors options through runHttp (0.3.2)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ledric",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "ledric CLI — single-binary entry point.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -50,7 +50,7 @@ export const DEFAULTS: InitAnswers = {
 // Version pin for the @ledric/proxy dep we add to a consumer's
 // package.json. Kept in lockstep with the CLI's own version — bump on
 // each release that ships a proxy change.
-export const PROXY_DEP_VERSION = '^0.3.1';
+export const PROXY_DEP_VERSION = '^0.3.2';
 
 const LEDRIC_GITIGNORE_LINES: readonly string[] = [
   '# ledric',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "ledric core: schema engine, versioning, refs, validation, ACL. DB-agnostic.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/gui",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "ledric admin GUI — React via CDN, served by @ledric/http-server.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/http-server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "ledric HTTP server: tool-shaped POST /rpc + REST GET projections, built on Fastify, binding @ledric/core.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/http-server/src/runner.test.ts
+++ b/packages/http-server/src/runner.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { Core } from '@ledric/core';
+import { openSqlite } from '@ledric/storage';
+import { runHttp } from './runner.js';
+
+// Regression for the 0.3.0/0.3.1 bug where `runHttp` constructed its
+// own subset of HttpServerOptions and silently dropped `mcp`. Result:
+// `serve --http-mcp --public-mcp` returned 404 on /mcp because the
+// route was never registered. The fix has runHttp spread its opts
+// straight through to createHttpServer; this test holds it there.
+describe('runHttp option pass-through', () => {
+  it('forwards mcp.http so /mcp is mounted', async () => {
+    const storage = await openSqlite({ path: ':memory:' });
+    const core = new Core(storage);
+    const server = await runHttp(core, {
+      port: 0,
+      host: '127.0.0.1',
+      mcp: { http: true },
+      auth: { storage }
+    });
+    try {
+      const res = await fetch(`${server.url}/mcp`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+      });
+      // Exactly the 404 envelope the user hit through the Cloudflare
+      // tunnel — if /mcp isn't mounted, this body comes back.
+      const body = (await res.json()) as unknown;
+      expect(body).not.toEqual({ error: { code: 'NOT_FOUND', message: 'route /mcp' } });
+    } finally {
+      await server.close();
+      await storage.close();
+    }
+  });
+});

--- a/packages/http-server/src/runner.ts
+++ b/packages/http-server/src/runner.ts
@@ -1,14 +1,13 @@
 import type { Core } from '@ledric/core';
 import { createHttpServer } from './server.js';
-import type { HttpAuthOptions } from './server.js';
+import type { HttpServerOptions } from './server.js';
 
-export interface RunHttpOptions {
+// Extends HttpServerOptions so any field added there is automatically
+// forwarded — adding a field to HttpServerOptions and forgetting to
+// thread it through this runner is what shipped /mcp as a 404 in 0.3.0.
+export interface RunHttpOptions extends HttpServerOptions {
   port?: number;
   host?: string;
-  logger?: boolean;
-  gui?: { assetsPath: string; mountPath?: string };
-  uploadLimitBytes?: number;
-  auth?: HttpAuthOptions;
 }
 
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '[::1]']);
@@ -36,12 +35,7 @@ export async function runHttp(core: Core, opts: RunHttpOptions = {}): Promise<{
     );
   }
 
-  const serverOpts: Parameters<typeof createHttpServer>[1] = {
-    logger: opts.logger ?? false
-  };
-  if (opts.gui !== undefined) serverOpts.gui = opts.gui;
-  if (opts.uploadLimitBytes !== undefined) serverOpts.uploadLimitBytes = opts.uploadLimitBytes;
-  if (opts.auth !== undefined) serverOpts.auth = opts.auth;
+  const { port: _port, host: _host, ...serverOpts } = opts;
   const app = createHttpServer(core, serverOpts);
 
   // fastify.listen() returns the actual bound URL — important when port is 0

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/mcp-server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "ledric MCP server: MCP tool surface bound to @ledric/core (stdio + HTTP+SSE).",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/oauth",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "OAuth 2.1 provider for ledric — DCR + auth code + PKCE + JWT/JWKS, single-process, no external IdP. Mounted by @ledric/http-server when mcp.public is on.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/proxy",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Server-side proxy primitive for ledric — keeps the browser off the ledric origin and keys off the client. Framework-agnostic (Request) => Promise<Response> handlers.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/schema",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "ledric schema definition helpers: defineType, field.*, JSON emit, Zod codegen.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "ledric vanilla TypeScript read client SDK.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/storage",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "ledric storage: Kysely-based dialect adapters. SQLite (better-sqlite3) default; MySQL and Postgres also supported.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

\`runHttp\` was hand-copying a subset of \`HttpServerOptions\` into the inner \`createHttpServer\` call — only \`logger\`, \`gui\`, \`uploadLimitBytes\`, and \`auth\` were on that copy list. \`mcp\` (and \`cors\`) were silently dropped on the floor.

End-user impact: \`serve --http-mcp --public-mcp\` reached \`createHttpServer\` with \`opts.mcp === undefined\`, \`mcpHttpFlag\` evaluated false, and \`/mcp\` was never registered. Caught while testing remote MCP via Cloudflare tunnel — MCP Inspector hit the tunnel and got our default 404 envelope:

\`\`\`
StreamableHTTPError: Streamable HTTP error: Error POSTing to endpoint:
{"error":{"code":"NOT_FOUND","message":"route /mcp"}}
\`\`\`

The OAuth dance can't even start because there's nothing to authenticate against.

## Fix

\`RunHttpOptions\` now extends \`HttpServerOptions\` and \`runHttp\` passes options through verbatim (minus \`port\`/\`host\`). Adding a field to \`HttpServerOptions\` and forgetting to thread it through this runner won't be possible anymore — the type system carries it.

## Why it slipped past 0.3.0 and 0.3.1

Every existing \`/mcp\` test boots via \`createHttpServer\` directly. \`runHttp\` was never exercised end-to-end. Adds \`packages/http-server/src/runner.test.ts\` that boots through \`runHttp\` and asserts \`/mcp\` doesn't return our \`NOT_FOUND\` envelope. Verified the test fails under the bug (re-ran with the fix reverted) and passes under the fix.

This PR is the user-facing critical bug; #17 closes the orthogonal gap (broken module-load slipping through publish). Either order works for landing — neither conflicts.

## Test plan

- [x] \`pnpm test\` — 427 passing (was 426 + the new regression test)
- [x] Verified test fails under the bug
- [x] Verified test passes under the fix
- [ ] Smoke against real Cloudflare tunnel post-merge
- [x] Bumps to 0.3.2 across the workspace; \`PROXY_DEP_VERSION\` follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)