### PR TITLE
feat: persistent JWKS + silence startup NOTICEs (0.3.4)

### DIFF
--- a/e2e-cli/cli-flow.test.ts
+++ b/e2e-cli/cli-flow.test.ts
@@ -52,7 +52,14 @@ async function reservePort(): Promise<number> {
   });
 }
 
-async function bootCli(): Promise<Env> {
+interface BootOpts {
+  /** Reuse an existing tmpdir + DB + config for restart-persistence tests. */
+  tmpdir?: string;
+  /** Reuse an existing port (so issuer URL stays stable across restarts). */
+  port?: number;
+}
+
+async function bootCli(opts: BootOpts = {}): Promise<Env> {
   if (!existsSync(CLI_PATH)) {
     throw new Error(
       `CLI dist missing at ${CLI_PATH}. Run \`pnpm build\` first — this e2e ` +
@@ -60,13 +67,15 @@ async function bootCli(): Promise<Env> {
     );
   }
 
-  const port = await reservePort();
+  const port = opts.port ?? (await reservePort());
   const issuer = `http://127.0.0.1:${port}`;
-  const tmp = await mkdtemp(join(tmpdir(), 'ledric-e2e-'));
-  await writeFile(
-    join(tmp, 'ledric.config.json'),
-    JSON.stringify({ db: './ledric.db', publicUrl: issuer }, null, 2)
-  );
+  const tmp = opts.tmpdir ?? (await mkdtemp(join(tmpdir(), 'ledric-e2e-')));
+  if (opts.tmpdir === undefined) {
+    await writeFile(
+      join(tmp, 'ledric.config.json'),
+      JSON.stringify({ db: './ledric.db', publicUrl: issuer }, null, 2)
+    );
+  }
 
   const proc = spawn(
     'node',
@@ -112,10 +121,15 @@ async function bootCli(): Promise<Env> {
     if (!ready) {
       ready = stderrBuf.includes('ledric: HTTP server at');
     }
+    // Restart-mode (existing tmpdir): bootstrap is skipped because
+    // the DB already has keys, so the admin-key banner never prints.
+    // Treat readiness alone as boot-complete in that case.
+    if (opts.tmpdir !== undefined && ready) break;
     if (adminKey !== undefined && ready) break;
     await new Promise((r) => setTimeout(r, 50));
   }
-  if (adminKey === undefined || !ready) {
+  const adminRequired = opts.tmpdir === undefined;
+  if ((adminRequired && adminKey === undefined) || !ready) {
     proc.kill('SIGTERM');
     throw new Error(
       `CLI did not boot fully within ${BOOT_TIMEOUT_MS}ms. ` +
@@ -128,26 +142,29 @@ async function bootCli(): Promise<Env> {
     proc,
     url: issuer,
     issuer,
-    adminKey,
+    adminKey: adminKey ?? '',
     tmpdir: tmp,
     stderrBuf
   };
 }
 
-async function teardown(env: Env): Promise<void> {
-  if (env.proc.exitCode === null) {
-    env.proc.kill('SIGTERM');
-    await new Promise<void>((r) => {
-      const t = setTimeout(() => {
-        env.proc.kill('SIGKILL');
-        r();
-      }, 3000);
-      env.proc.once('exit', () => {
-        clearTimeout(t);
-        r();
-      });
+async function killProc(env: Env): Promise<void> {
+  if (env.proc.exitCode !== null) return;
+  env.proc.kill('SIGTERM');
+  await new Promise<void>((r) => {
+    const t = setTimeout(() => {
+      env.proc.kill('SIGKILL');
+      r();
+    }, 3000);
+    env.proc.once('exit', () => {
+      clearTimeout(t);
+      r();
     });
-  }
+  });
+}
+
+async function teardown(env: Env): Promise<void> {
+  await killProc(env);
   await rm(env.tmpdir, { recursive: true, force: true });
 }
 
@@ -385,5 +402,55 @@ describe('e2e: CLI public-MCP flow against the built binary', () => {
     expect(initRes.status).toBe(200);
     const sessionId = initRes.headers.get('mcp-session-id');
     expect(sessionId, 'mcp-session-id header missing on initialize').not.toBeNull();
+  });
+});
+
+// Regression: signing keys must persist across `serve` restarts.
+// Without persistence, oidc-provider auto-mints dev-mode keys at boot
+// — every restart invalidates issued JWTs and claude.ai connectors
+// silently lose their connection. The test boots the CLI, captures
+// /oauth/jwks, kills the subprocess, boots again on the SAME tmpdir,
+// captures /oauth/jwks a second time, and asserts the keys (kid, kty,
+// modulus n) match. Drift means we lost persistence.
+describe('e2e: OAuth signing keys persist across restart', () => {
+  let env1: Env | undefined;
+  let env2: Env | undefined;
+
+  afterAll(async () => {
+    if (env2) await teardown(env2);
+    else if (env1) await teardown(env1);
+  });
+
+  it('issues the same JWKS kid + n after a full restart', async () => {
+    env1 = await bootCli();
+    const jwks1 = (await (
+      await fetch(`${env1.url}/oauth/jwks`)
+    ).json()) as { keys: Array<{ kid: string; kty: string; n?: string }> };
+    expect(jwks1.keys.length).toBeGreaterThan(0);
+    const k1 = jwks1.keys[0]!;
+
+    // oidc-provider's dev-mode fallback uses a hardcoded keystore
+    // shipped in npm — `kid: keystore-CHANGE-ME` with a fixed RSA
+    // key that ANY oidc-provider install can sign with. That's a
+    // forge-tokens-for-anyone bug masquerading as a quick-start
+    // convenience. If kid is that sentinel, persistence isn't wired.
+    expect(k1.kid, 'using oidc-provider dev keystore — persistence not wired').not.toBe(
+      'keystore-CHANGE-ME'
+    );
+
+    // Kill subprocess but keep tmpdir + DB.
+    await killProc(env1);
+
+    const port1 = Number(new URL(env1.url).port);
+    env2 = await bootCli({ tmpdir: env1.tmpdir, port: port1 });
+    const jwks2 = (await (
+      await fetch(`${env2.url}/oauth/jwks`)
+    ).json()) as { keys: Array<{ kid: string; kty: string; n?: string }> };
+    expect(jwks2.keys.length).toBeGreaterThan(0);
+    const k2 = jwks2.keys[0]!;
+
+    expect(k2.kid).toBe(k1.kid);
+    expect(k2.kty).toBe(k1.kty);
+    expect(k2.n).toBe(k1.n);
   });
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ledric",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "ledric CLI — single-binary entry point.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -50,7 +50,7 @@ export const DEFAULTS: InitAnswers = {
 // Version pin for the @ledric/proxy dep we add to a consumer's
 // package.json. Kept in lockstep with the CLI's own version — bump on
 // each release that ships a proxy change.
-export const PROXY_DEP_VERSION = '^0.3.3';
+export const PROXY_DEP_VERSION = '^0.3.4';
 
 const LEDRIC_GITIGNORE_LINES: readonly string[] = [
   '# ledric',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/core",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "ledric core: schema engine, versioning, refs, validation, ACL. DB-agnostic.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/gui",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "ledric admin GUI — React via CDN, served by @ledric/http-server.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/http-server",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "ledric HTTP server: tool-shaped POST /rpc + REST GET projections, built on Fastify, binding @ledric/core.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/http-server/src/oauth-routes.ts
+++ b/packages/http-server/src/oauth-routes.ts
@@ -3,6 +3,7 @@ import type { LedricStorage } from '@ledric/storage';
 import { hashApiKey } from '@ledric/storage';
 import {
   buildProvider,
+  loadOrCreateSigningKey,
   reapExpiredOidcPayloads,
   SCOPE_TO_ROLE,
   type AccessTokenClaims,
@@ -40,8 +41,15 @@ export async function mountOAuthRoutes(
   storage: LedricStorage,
   opts: OAuthMountOptions
 ): Promise<{ verify: AccessTokenVerifier; close: () => void }> {
+  // Load (or first-boot mint) the persistent signing key. Without
+  // this oidc-provider auto-generates dev-mode keys per process —
+  // every restart invalidates issued JWTs and claude.ai connectors
+  // silently lose their connection.
+  const signingKey = await loadOrCreateSigningKey(storage);
+
   const provider = buildProvider(storage, {
     issuer: opts.issuer,
+    jwks: { keys: [signingKey] },
     ...(opts.dcr !== undefined ? { dcr: opts.dcr } : {}),
     ...(opts.accessTokenTtlSeconds !== undefined
       ? { accessTokenTtlSeconds: opts.accessTokenTtlSeconds }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/mcp-server",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "ledric MCP server: MCP tool surface bound to @ledric/core (stdio + HTTP+SSE).",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/oauth",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OAuth 2.1 provider for ledric — DCR + auth code + PKCE + JWT/JWKS, single-process, no external IdP. Mounted by @ledric/http-server when mcp.public is on.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -8,3 +8,5 @@ export { buildProvider, KyselyOidcAdapter, reapExpiredOidcPayloads } from './pro
 
 export type { ClientSummary } from './clients.js';
 export { listClients, revokeClient } from './clients.js';
+
+export { loadOrCreateSigningKey } from './keys.js';

--- a/packages/oauth/src/keys.ts
+++ b/packages/oauth/src/keys.ts
@@ -1,0 +1,56 @@
+import type { LedricStorage } from '@ledric/storage';
+import { generateKeyPair, exportJWK, type JWK } from 'jose';
+import { randomBytes } from 'node:crypto';
+
+/**
+ * Load the persistent OAuth signing key from the DB, or generate +
+ * persist one on first call. The returned JWK is private (RSA: has
+ * `d`, `p`, `q`, `dp`, `dq`, `qi` plus `n` and `e`) and tagged with
+ * `kid`, `use: 'sig'`, `alg: 'RS256'`.
+ *
+ * Without persistence, oidc-provider auto-generates dev-mode keys at
+ * boot — restarting `serve` invalidates every issued JWT. claude.ai
+ * connectors and other long-lived MCP clients silently lose their
+ * connection. The whole point of this helper is to keep keys stable
+ * across restarts so already-authenticated clients keep working.
+ *
+ * Single-row layout for now. Multi-row + rotation is a future
+ * concern; today we want one stable RS256 keypair per ledric instance.
+ */
+export async function loadOrCreateSigningKey(
+  storage: LedricStorage
+): Promise<JWK> {
+  const existing = await storage.db
+    .selectFrom('oidc_signing_keys')
+    .select(['kid', 'jwk', 'alg'])
+    .orderBy('created_at', 'asc')
+    .limit(1)
+    .executeTakeFirst();
+  if (existing !== undefined) {
+    const parsed = JSON.parse(existing.jwk) as JWK;
+    parsed.kid = existing.kid;
+    parsed.alg = existing.alg;
+    return parsed;
+  }
+
+  // RSA-2048 RS256 to match the signing alg advertised by
+  // resourceIndicators.getResourceServerInfo. Generate, export to
+  // private JWK, attach a stable kid, persist, return.
+  const { privateKey } = await generateKeyPair('RS256', { modulusLength: 2048 });
+  const jwk = (await exportJWK(privateKey)) as JWK;
+  jwk.kid = randomBytes(8).toString('hex');
+  jwk.alg = 'RS256';
+  jwk.use = 'sig';
+
+  await storage.db
+    .insertInto('oidc_signing_keys')
+    .values({
+      kid: jwk.kid,
+      jwk: JSON.stringify(jwk),
+      alg: 'RS256',
+      created_at: Date.now()
+    })
+    .execute();
+
+  return jwk;
+}

--- a/packages/oauth/src/provider.ts
+++ b/packages/oauth/src/provider.ts
@@ -1,5 +1,5 @@
 import Provider from 'oidc-provider';
-import type { Configuration, KoaContextWithOIDC, Account, FindAccount } from 'oidc-provider';
+import type { Configuration, KoaContextWithOIDC, Account, FindAccount, JWKS } from 'oidc-provider';
 import type { LedricStorage } from '@ledric/storage';
 import { KyselyOidcAdapter } from './adapter.js';
 
@@ -10,6 +10,14 @@ export interface BuildProviderOptions {
   dcr?: boolean;
   accessTokenTtlSeconds?: number;
   refreshTokenTtlSeconds?: number;
+  /**
+   * Persistent signing keys. When omitted, oidc-provider generates
+   * dev-mode keys at boot — fine for unit tests, broken for real use
+   * because every restart invalidates issued JWTs. Production path
+   * (and the public-MCP serve flow) supplies keys from
+   * `loadOrCreateSigningKey(storage)`.
+   */
+  jwks?: JWKS;
 }
 
 /**
@@ -95,14 +103,34 @@ export function buildProvider(
       RefreshToken: refreshTokenTtl,
       Session: 7 * 24 * 3600,
       Interaction: 600,
-      Grant: refreshTokenTtl
+      Grant: refreshTokenTtl,
+      // We don't issue ID tokens (no openid scope, userinfo disabled),
+      // but oidc-provider still resolves ttl.IdToken at config time
+      // and logs a NOTICE if the default placeholder fires. Set a
+      // value to silence it — never actually used.
+      IdToken: 3600
     },
+    // claude.ai (and other browser-launched connector setups) make
+    // CORS requests against the OAuth endpoints. The default returns
+    // false, which logs a "default clientBasedCORS function called"
+    // NOTICE on every browser hit. Allow CORS for any registered
+    // client — security still gates on PKCE + admin-key consent +
+    // audience-bound JWTs. (The outer @fastify/cors plugin already
+    // adds wire-level Access-Control-* headers; this just silences
+    // the NOTICE and keeps oidc-provider's view of CORS coherent.)
+    clientBasedCORS: () => true,
     // Always mint refresh tokens for confirmed grants — resource-server
     // JWTs are short-lived and clients need a way to extend their
     // session without re-prompting for consent.
     issueRefreshToken: async (_ctx, _client, code) =>
       code.scopes !== undefined && code.scopes.size > 0,
     findAccount,
+    // Persistent signing keys (when supplied — see @ledric/oauth's
+    // `loadOrCreateSigningKey`). Without this, oidc-provider mints
+    // dev-mode keys at boot and prints "quick start development-only
+    // signing keys are used". JWTs signed by those keys don't survive
+    // a restart, so claude.ai connectors silently break.
+    ...(opts.jwks !== undefined ? { jwks: opts.jwks } : {}),
     interactions: {
       url: (_ctx, interaction) => `/oauth/consent/${interaction.uid}`
     },

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/proxy",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Server-side proxy primitive for ledric — keeps the browser off the ledric origin and keys off the client. Framework-agnostic (Request) => Promise<Response> handlers.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/schema",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "ledric schema definition helpers: defineType, field.*, JSON emit, Zod codegen.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/sdk",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "ledric vanilla TypeScript read client SDK.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/storage",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "ledric storage: Kysely-based dialect adapters. SQLite (better-sqlite3) default; MySQL and Postgres also supported.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/storage/src/migrations/mysql.ts
+++ b/packages/storage/src/migrations/mysql.ts
@@ -228,5 +228,17 @@ export const mysqlMigrations: Migration[] = [
         INDEX idx_oidc_payloads_expires   (expires_at)
       ) ENGINE=InnoDB;
     `
+  },
+  {
+    id: 4,
+    name: '0004_signing_keys',
+    sql: `
+      CREATE TABLE oidc_signing_keys (
+        kid        VARCHAR(191) PRIMARY KEY,
+        jwk        TEXT         NOT NULL,
+        alg        VARCHAR(32)  NOT NULL,
+        created_at BIGINT       NOT NULL
+      ) ENGINE=InnoDB;
+    `
   }
 ];

--- a/packages/storage/src/migrations/postgres.ts
+++ b/packages/storage/src/migrations/postgres.ts
@@ -215,5 +215,17 @@ export const postgresMigrations: Migration[] = [
       CREATE INDEX idx_oidc_payloads_uid       ON oidc_payloads (uid);
       CREATE INDEX idx_oidc_payloads_expires   ON oidc_payloads (expires_at);
     `
+  },
+  {
+    id: 4,
+    name: '0004_signing_keys',
+    sql: `
+      CREATE TABLE oidc_signing_keys (
+        kid        TEXT   PRIMARY KEY,
+        jwk        TEXT   NOT NULL,
+        alg        TEXT   NOT NULL,
+        created_at BIGINT NOT NULL
+      );
+    `
   }
 ];

--- a/packages/storage/src/migrations/sqlite.ts
+++ b/packages/storage/src/migrations/sqlite.ts
@@ -230,5 +230,27 @@ export const sqliteMigrations: Migration[] = [
       CREATE INDEX idx_oidc_payloads_uid       ON oidc_payloads (uid);
       CREATE INDEX idx_oidc_payloads_expires   ON oidc_payloads (expires_at);
     `
+  },
+  {
+    id: 4,
+    name: '0004_signing_keys',
+    sql: `
+      -- Persistent JWT signing keys for the OAuth provider. Without
+      -- these, oidc-provider auto-generates dev-mode keys at boot —
+      -- which means every \`serve\` restart invalidates every issued
+      -- JWT. claude.ai connectors persist across sessions and would
+      -- silently lose their connection on each restart.
+      --
+      -- One row per active key. Multi-row layout is for future
+      -- rotation; today we only ever populate a single RS256 key on
+      -- first boot in public mode.
+
+      CREATE TABLE oidc_signing_keys (
+        kid        TEXT    PRIMARY KEY,
+        jwk        TEXT    NOT NULL,    -- private JWK as JSON
+        alg        TEXT    NOT NULL,    -- 'RS256' for now
+        created_at INTEGER NOT NULL
+      ) STRICT;
+    `
   }
 ];

--- a/packages/storage/src/schema.ts
+++ b/packages/storage/src/schema.ts
@@ -141,6 +141,22 @@ export interface OidcPayloadsTable {
   consumed_at: number | null;
 }
 
+/**
+ * Persistent OAuth signing keys. Without these, oidc-provider falls
+ * back to dev-mode auto-keys at boot — restarting `serve` would
+ * silently invalidate every issued JWT (claude.ai connectors lose
+ * their connection). One row per active key; multi-row layout is
+ * for future rotation.
+ */
+export interface OidcSigningKeysTable {
+  kid: string;
+  /** JSON-stringified private JWK. */
+  jwk: string;
+  alg: string;
+  /** Unix milliseconds. */
+  created_at: number;
+}
+
 export interface TagsTable {
   id: Buffer;
   env_id: Buffer;
@@ -202,6 +218,7 @@ export interface Database {
   asset_blobs: AssetBlobsTable;
   api_keys: ApiKeysTable;
   oidc_payloads: OidcPayloadsTable;
+  oidc_signing_keys: OidcSigningKeysTable;
   tags: TagsTable;
   asset_tags: AssetTagsTable;
   entry_tags: EntryTagsTable;

--- a/packages/storage/src/storage.mysql.test.ts
+++ b/packages/storage/src/storage.mysql.test.ts
@@ -17,6 +17,7 @@ const TABLES = [
   'asset_tags',
   'tags',
   'api_keys',
+  'oidc_signing_keys',
   'oidc_payloads',
   'entries_slugs',
   'slug_history',

--- a/packages/storage/src/storage.postgres.test.ts
+++ b/packages/storage/src/storage.postgres.test.ts
@@ -20,6 +20,7 @@ const TABLES = [
   'asset_tags',
   'tags',
   'api_keys',
+  'oidc_signing_keys',
   'oidc_payloads',
   'entries_slugs',
   'slug_history',


### PR DESCRIPTION
## Summary

Closes the *every-restart-breaks-claude.ai* gap, plus surfaces a security finding worse than the original bug, plus silences the two startup NOTICEs operators have been seeing on every public-MCP boot.

## The security finding

Investigating the persistence work revealed that without an explicit `jwks` config, **oidc-provider falls back to a hardcoded dev keystore shipped inside the npm package**. The kid is literally `keystore-CHANGE-ME` and the RSA key is identical across every install of `oidc-provider`. Until this PR, every public-MCP ledric on the planet was signing JWTs with the same publicly-known private key.

The audience claim (`<publicUrl>/mcp`) and issuer pinning prevented cross-instance forgery in practice, but it's still a "this is the kind of thing that leaks past those checks one day" bug that should never have been live.

Verified by booting twice with no fix and observing identical `kid: keystore-CHANGE-ME` JWKS — same `n`, same `e`, deterministic across processes.

## What this PR does

### 1. Persistent JWKS (`feat`)

- **Migration `0004_signing_keys`** in all three dialects (sqlite/postgres/mysql). Creates an `oidc_signing_keys` table: `{ kid, jwk (private JSON), alg, created_at }`. Multi-row layout for future rotation; today we only ever write one row.
- **`@ledric/oauth/loadOrCreateSigningKey(storage)`** — reads the first row by `created_at`; on empty, generates a fresh RS256 keypair via `jose`, exports the private JWK, stamps a random kid, persists, returns it.
- **`buildProvider`** now accepts a `jwks` option; **`mountOAuthRoutes`** calls `loadOrCreateSigningKey` and passes the result.

### 2. NOTICE silencing (`fix`)

Two startup NOTICEs from oidc-provider have been firing on every public-MCP boot:

- `clientBasedCORS` — claude.ai's connector setup makes browser-driven CORS requests. `@fastify/cors` at the outer layer already handles wire-level CORS, but oidc-provider logs the NOTICE until `clientBasedCORS` is configured. Set to `() => true` — security still gates on PKCE + admin-key consent + audience-bound JWTs.
- `ttl.IdToken` — we don't issue ID tokens (no openid scope, userinfo disabled), but oidc-provider resolves `ttl.IdToken` at config time. Set to `3600` to silence the NOTICE; the value is never actually used.

### 3. Regression test (`test`)

`e2e-cli/cli-flow.test.ts` parameterized: `bootCli({ tmpdir, port })` now reuses an existing tmpdir + port across boots. New describe block boots twice against the same DB, captures `/oauth/jwks` each time, and asserts:

- `kid !== 'keystore-CHANGE-ME'` — proves we're not on the dev keystore fallback
- `kid` + `n` stable across restarts — proves persistence

Verified the test catches the regression: reverted the `jwks: { keys: [signingKey] }` line in `mountOAuthRoutes` and saw:

```
expected 'keystore-CHANGE-ME' not to be 'keystore-CHANGE-ME'
```

…with the diagnostic message *"using oidc-provider dev keystore — persistence not wired"* attached.

## Migration safety

`0004_signing_keys` is purely additive: `CREATE TABLE` only, no data migration, no existing-row touches. Safe to apply to any 0.3.x DB.

The first boot after upgrading mints a fresh key. **Existing OAuth tokens (signed by the dev keystore) will not validate against the new key** — claude.ai connectors set up against pre-0.3.4 instances will need to disconnect + reconnect once. That's a one-time cost; future restarts preserve the connection.

## Test plan

- [x] `pnpm test` — 435 passing (was 434 + persistence regression)
- [x] `pnpm typecheck` — only the four pre-existing unrelated errors remain
- [x] Reverted the fix → e2e fails with the explicit "dev keystore" message
- [x] Restored the fix → e2e green, including the existing 5-step OAuth flow
- [ ] Smoke against real claude.ai connector post-merge (existing tunnel: tunnel.getledric.com)

## Bumps

All packages → **0.3.4**. `PROXY_DEP_VERSION` follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)