### PR TITLE
feat(0.3.5): proxy-mode base URL + inline preview toggle + Laravel deployment docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,6 +13,7 @@ exists.
 - [The packages](#the-packages)
 - [Inside the ledric process](#inside-the-ledric-process)
 - [The two-process consumer pattern](#the-two-process-consumer-pattern)
+- [Locked-down deployments (Laravel + nginx)](#locked-down-deployments-laravel--nginx)
 - [Storage adapters](#storage-adapters)
 - [The asset pipeline](#the-asset-pipeline)
 - [The inline editor](#the-inline-editor)
@@ -288,6 +289,106 @@ asset uploads, write operations) without leaking the admin key
 into the browser, it mounts `@ledric/proxy` server-side. The
 proxy holds the admin key in environment variables and exposes
 a curated subset of ledric's surface to the browser.
+
+---
+
+## Locked-down deployments (Laravel + nginx)
+
+Some deployments don't want ledric reachable from the public
+internet at all — corporate networks, regulated stacks, or "I
+already run a Laravel app and that's the only public surface I
+want to maintain." The `ledric/laravel` Composer package covers
+this case: it makes Laravel the single public face, with ledric
+listening only on `127.0.0.1`.
+
+```
+┌──────────────┐      ┌────────────────────────┐    ┌────────────┐
+│  Browser     │      │  Laravel (public)      │    │  ledric    │
+│  / CDN       ├─────►│  - admin GUI proxy      ├───►│ 127.0.0.1  │
+│              │      │  - asset proxy + cache  │    │ (no public │
+│              │      │  - reader/admin API     │    │  binding)  │
+└──────────────┘      └────────────────────────┘    └────────────┘
+                                                          ▲
+                            ┌────────────┐                │
+   MCP clients ────────────►│  nginx     ├────────────────┘
+   (claude.ai connectors)   │  /mcp + .well-known/*
+                            │  proxied directly
+                            └────────────┘
+```
+
+The Laravel package handles every *human-driven* surface:
+
+- The inline admin GUI: every `/ledric-admin/*` request streams
+  through the package's `AdminProxyController`, gated by an
+  allow-list of Laravel user IDs.
+- Asset bytes: `/ledric-assets/<ref_key>` is fetched from ledric
+  on first hit, cached in Laravel's cache (immutable — `ref_key`
+  rotates on every byte replacement), and served with
+  `Cache-Control: public, max-age=31536000, immutable`.
+- Reader/admin API calls from the consumer site go through
+  `Ledric::find()` etc., cached with stale-while-error so a
+  ledric outage degrades gracefully instead of blanking the site.
+
+### Why MCP doesn't go through Laravel
+
+Public-MCP uses Streamable HTTP — long-lived connections that
+stay open for the lifetime of the MCP session. Under PHP-FPM
+that's one tied-up worker per connected client. A pool of 8–32
+workers gets exhausted by 8–32 simultaneous claude.ai
+connections. The whole point of public-MCP is *agents at scale*,
+which is exactly what FPM is bad at.
+
+So the MCP surface bypasses Laravel and goes directly to
+ledric via a small nginx (or Caddy) location block:
+
+```nginx
+# /etc/nginx/sites-available/example.com
+server {
+  server_name example.com;
+  listen 443 ssl http2;
+  # ... TLS config ...
+
+  # MCP + OAuth metadata go straight to ledric.
+  # ledric's OAuth provider handles auth — no app-level gating needed.
+  location /mcp {
+    proxy_pass http://127.0.0.1:3030;
+    proxy_http_version 1.1;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Forwarded-Host  $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_buffering off;            # streamable HTTP needs no buffering
+    proxy_read_timeout 24h;         # MCP sessions are long-lived
+    proxy_send_timeout 24h;
+  }
+
+  location /.well-known/oauth-authorization-server {
+    proxy_pass http://127.0.0.1:3030;
+  }
+  location /.well-known/oauth-protected-resource {
+    proxy_pass http://127.0.0.1:3030;
+  }
+  # /auth, /token, /register, /jwks, /consent — same shape.
+  location ~ ^/(auth|token|register|jwks|consent) {
+    proxy_pass http://127.0.0.1:3030;
+  }
+
+  # Everything else is the Laravel app.
+  location / {
+    try_files $uri /index.php?$query_string;
+    # ... standard Laravel + php-fpm config ...
+  }
+}
+```
+
+ledric still needs to know its public issuer URL so JWTs are
+minted with the right `iss` claim — set `mcp.publicUrl` (or
+`LEDRIC_MCP_PUBLIC_URL`) to `https://example.com`. The
+authorization server discovery doc and JWKS will then be
+correctly addressed.
+
+Both Laravel and the MCP paths share the same ledric process
+and the same database; they're just different access routes
+into it.
 
 ---
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ledric",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "ledric CLI — single-binary entry point.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -50,7 +50,7 @@ export const DEFAULTS: InitAnswers = {
 // Version pin for the @ledric/proxy dep we add to a consumer's
 // package.json. Kept in lockstep with the CLI's own version — bump on
 // each release that ships a proxy change.
-export const PROXY_DEP_VERSION = '^0.3.4';
+export const PROXY_DEP_VERSION = '^0.3.5';
 
 const LEDRIC_GITIGNORE_LINES: readonly string[] = [
   '# ledric',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/core",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "ledric core: schema engine, versioning, refs, validation, ACL. DB-agnostic.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/gui",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "ledric admin GUI — React via CDN, served by @ledric/http-server.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/gui/web/inline.js
+++ b/packages/gui/web/inline.js
@@ -226,8 +226,83 @@
     mutTimer = setTimeout(() => scan(document), 150);
   }
 
+  // ---- preview toggle ----------------------------------------------------
+  // Visible only when the host page sets `window.LEDRIC_PREVIEW_AVAILABLE`
+  // = true (the admin user's renderer opts in). State comes from
+  // `window.LEDRIC_PREVIEW`. Click POSTs to `<mountPath>/preview-toggle`
+  // and reloads — Laravel's package handles that route by toggling a
+  // cookie. Standalone ledric installs ignore both globals (nothing is
+  // emitted), so this is a no-op outside the proxy setup.
+
+  function ensurePreviewToggle() {
+    if (!window.LEDRIC_PREVIEW_AVAILABLE) return;
+    if (document.getElementById('ledric-preview-toggle')) return;
+
+    const active = window.LEDRIC_PREVIEW === true;
+    const btn = document.createElement('button');
+    btn.id = 'ledric-preview-toggle';
+    btn.type = 'button';
+    btn.textContent = active ? 'Preview: ON' : 'Preview: OFF';
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+    Object.assign(btn.style, {
+      position: 'fixed',
+      bottom: '16px',
+      right: '16px',
+      zIndex: '2147483645',
+      padding: '8px 14px',
+      borderRadius: '999px',
+      border: 'none',
+      background: active ? '#f59e0b' : '#3f3f46',
+      color: active ? '#18181b' : '#fafafa',
+      fontFamily: 'system-ui, -apple-system, sans-serif',
+      fontSize: '13px',
+      fontWeight: '600',
+      cursor: 'pointer',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+      transition: 'transform 0.1s ease'
+    });
+    btn.addEventListener('mouseenter', () => { btn.style.transform = 'scale(1.05)'; });
+    btn.addEventListener('mouseleave', () => { btn.style.transform = 'scale(1)'; });
+    btn.addEventListener('click', async () => {
+      btn.disabled = true;
+      btn.style.opacity = '0.7';
+      try {
+        const res = await fetch(apiBase + mountPath + '/preview-toggle', {
+          method: 'POST',
+          credentials: 'same-origin'
+        });
+        if (res.ok) {
+          location.reload();
+          return;
+        }
+      } catch { /* fall through */ }
+      btn.disabled = false;
+      btn.style.opacity = '1';
+    });
+
+    if (active) {
+      // Thin top banner so it's hard to forget you're looking at drafts.
+      const banner = document.createElement('div');
+      banner.id = 'ledric-preview-banner';
+      Object.assign(banner.style, {
+        position: 'fixed',
+        top: '0',
+        left: '0',
+        right: '0',
+        height: '3px',
+        background: '#f59e0b',
+        zIndex: '2147483645',
+        pointerEvents: 'none'
+      });
+      document.body.appendChild(banner);
+    }
+
+    document.body.appendChild(btn);
+  }
+
   function init() {
     scan(document);
+    ensurePreviewToggle();
     const mo = new MutationObserver(onMutation);
     mo.observe(document.body, {
       childList: true,

--- a/packages/gui/web/lib/api.js
+++ b/packages/gui/web/lib/api.js
@@ -1,7 +1,16 @@
 // Tiny fetch wrapper for the ledric HTTP API. Mirrors @ledric/sdk's surface
 // but uses the page origin (since the GUI is mounted on the same server).
+//
+// When the GUI is reached through a reverse proxy that prefixes URLs
+// (e.g. ledric/laravel mounting at /ledric-admin/...), the host server
+// injects `<script>window.LEDRIC_BASE_URL = "/ledric-admin"</script>`
+// into the index. fetch() resolves bare paths against current origin,
+// so a path-only base URL works for both inline-mode and proxy-mode.
 
-const ROOT = window.location.origin;
+const ROOT =
+  typeof window !== 'undefined' && typeof window.LEDRIC_BASE_URL === 'string'
+    ? window.LEDRIC_BASE_URL.replace(/\/+$/, '')
+    : window.location.origin;
 
 // localStorage key the admin paste-prompt writes to. Same origin as
 // the API, so the inline-editor iframe and the /admin SPA share it.

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/http-server",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "ledric HTTP server: tool-shaped POST /rpc + REST GET projections, built on Fastify, binding @ledric/core.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/http-server/src/server.test.ts
+++ b/packages/http-server/src/server.test.ts
@@ -545,6 +545,45 @@ describe('HTTP server with GUI mount', () => {
     expect(res.statusCode).toBe(404);
     expect(JSON.parse(res.body).error.code).toBe('NOT_FOUND');
   });
+
+  it('X-Forwarded-Prefix overrides <base href> so the proxy prefix wins', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/admin/',
+      headers: { accept: 'text/html', 'x-forwarded-prefix': '/ledric-admin' }
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('<base href="/ledric-admin/">');
+  });
+
+  it('X-Forwarded-Prefix injects window.LEDRIC_BASE_URL for api.js', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/admin/',
+      headers: { accept: 'text/html', 'x-forwarded-prefix': '/ledric-admin' }
+    });
+    expect(res.body).toContain('window.LEDRIC_BASE_URL="/ledric-admin"');
+  });
+
+  it('no X-Forwarded-Prefix → no LEDRIC_BASE_URL script (falls back to window.location.origin)', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/admin/',
+      headers: { accept: 'text/html' }
+    });
+    expect(res.body).not.toContain('LEDRIC_BASE_URL');
+  });
+
+  it('SPA deep-refresh under proxy prefix carries through to the injected base', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/admin/types/blog_post/nested',
+      headers: { accept: 'text/html', 'x-forwarded-prefix': '/ledric-admin/' }
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('<base href="/ledric-admin/">');
+    expect(res.body).toContain('window.LEDRIC_BASE_URL="/ledric-admin"');
+  });
 });
 
 describe('HTTP server with auth (admin-protects-writes default)', () => {

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -89,12 +89,53 @@ function parseOrderParam(raw: string | undefined): Array<{ field: string; dir: '
   return out;
 }
 
-function injectBaseHref(html: string, basePath: string): string {
-  const tag = `<base href="${basePath}">`;
-  if (/<base\s/i.test(html)) {
-    return html.replace(/<base\s[^>]*>/i, tag);
+/**
+ * Resolve the externally-visible mount prefix from a request. When
+ * fronted by a reverse proxy (ledric/laravel, nginx, traefik, etc.)
+ * the `X-Forwarded-Prefix` header carries the prefix the browser
+ * sees; without it we use the local GUI mount path. Always returns
+ * a trailing-slashed prefix.
+ */
+function resolveExternalPrefix(
+  headers: Record<string, string | string[] | undefined>,
+  fallback: string
+): string {
+  const raw = headers['x-forwarded-prefix'];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  const prefix = (typeof value === 'string' && value.length > 0 ? value : fallback).trim();
+  if (prefix.length === 0) return '/';
+  return prefix.endsWith('/') ? prefix : `${prefix}/`;
+}
+
+function injectGuiBootstrap(
+  html: string,
+  basePath: string,
+  externalPrefix: string
+): string {
+  // <base href="…/"> — fixes relative asset/script imports for SPA deep
+  // refresh. In proxy mode this must be the externally-visible prefix
+  // so `./app.js` resolves to a path the proxy will catch.
+  const baseTag = `<base href="${externalPrefix}">`;
+  let out = /<base\s/i.test(html)
+    ? html.replace(/<base\s[^>]*>/i, baseTag)
+    : html.replace(/<head[^>]*>/i, (m) => `${m}\n    ${baseTag}`);
+
+  // <base> doesn't help string-concatenation URLs (window.location.origin
+  // + "/types"). When proxied, also inject an explicit base URL the
+  // GUI's api.js reads. Skip when local mountPath equals externalPrefix
+  // — the existing window.location.origin fallback already produces the
+  // right URL there.
+  if (externalPrefix !== basePath) {
+    const trimmed = externalPrefix.replace(/\/+$/, '');
+    const script = `<script>window.LEDRIC_BASE_URL=${JSON.stringify(trimmed)};</script>`;
+    if (/<\/head>/i.test(out)) {
+      out = out.replace(/<\/head>/i, `    ${script}\n  </head>`);
+    } else {
+      out = out.replace(/<head[^>]*>/i, (m) => `${m}\n    ${script}`);
+    }
   }
-  return html.replace(/<head[^>]*>/i, (m) => `${m}\n    ${tag}`);
+
+  return out;
 }
 
 function guessKindFromMime(mime: string | undefined): string {
@@ -300,10 +341,11 @@ export function createHttpServer(core: Core, opts: HttpServerOptions = {}): Fast
     // and can inject <base href>. Without that, deep SPA paths like
     // /admin/types/blog_post/foo break relative imports (./app.js resolves
     // against the current URL, not the mount root).
-    const serveIndex = async (_req: unknown, reply: import('fastify').FastifyReply) => {
+    const serveIndex = async (req: import('fastify').FastifyRequest, reply: import('fastify').FastifyReply) => {
       try {
         const raw = await fs.readFile(indexPath, 'utf-8');
-        reply.code(200).type('text/html; charset=utf-8').send(injectBaseHref(raw, prefix));
+        const externalPrefix = resolveExternalPrefix(req.headers, prefix);
+        reply.code(200).type('text/html; charset=utf-8').send(injectGuiBootstrap(raw, prefix, externalPrefix));
       } catch (err) {
         reply.code(500).send({
           error: {
@@ -337,7 +379,8 @@ export function createHttpServer(core: Core, opts: HttpServerOptions = {}): Fast
       if (inMount && wantsHtml) {
         try {
           const raw = await fs.readFile(indexPath, 'utf-8');
-          reply.code(200).type('text/html; charset=utf-8').send(injectBaseHref(raw, prefix));
+          const externalPrefix = resolveExternalPrefix(req.headers, prefix);
+          reply.code(200).type('text/html; charset=utf-8').send(injectGuiBootstrap(raw, prefix, externalPrefix));
           return;
         } catch {
           // fall through to default

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/mcp-server",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "ledric MCP server: MCP tool surface bound to @ledric/core (stdio + HTTP+SSE).",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/oauth",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "OAuth 2.1 provider for ledric — DCR + auth code + PKCE + JWT/JWKS, single-process, no external IdP. Mounted by @ledric/http-server when mcp.public is on.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/proxy",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Server-side proxy primitive for ledric — keeps the browser off the ledric origin and keys off the client. Framework-agnostic (Request) => Promise<Response> handlers.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/schema",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "ledric schema definition helpers: defineType, field.*, JSON emit, Zod codegen.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/sdk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "ledric vanilla TypeScript read client SDK.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/storage",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "ledric storage: Kysely-based dialect adapters. SQLite (better-sqlite3) default; MySQL and Postgres also supported.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

Plumbing for the new [`ledric/laravel`](https://github.com/getledric/ledric-laravel) Composer package, plus an architecture-doc section covering the locked-down deployment topology.

- **`api.js`**: `ROOT` reads `window.LEDRIC_BASE_URL ?? window.location.origin`. Default behavior unchanged when nothing's injected — only proxied installs care.
- **`http-server`**: when a request carries `X-Forwarded-Prefix`, the GUI's `<base href>` reflects that externally-visible prefix and a `<script>window.LEDRIC_BASE_URL=…</script>` is injected so `api.js` builds URLs that hit the proxy. No header → no script → current behavior.
- **`inline.js`**: floating *Preview: ON / OFF* button + thin top banner when active. Only mounts when `window.LEDRIC_PREVIEW_AVAILABLE` is true (the Laravel package sets it for permitted users); standalone installs ignore both globals.
- **`docs/architecture.md`**: new "Locked-down deployments (Laravel + nginx)" section explaining why public-MCP bypasses Laravel (Streamable HTTP holds connections open; PHP-FPM doesn't survive that) and showing a sample nginx config.
- **Version bump** to 0.3.5 across all 9 packages + `PROXY_DEP_VERSION` in `cli/init.ts`.

## Test plan

- [x] `pnpm exec vitest run` — 439 passed (4 new tests in `server.test.ts` for the `X-Forwarded-Prefix` injection paths)
- [x] `pnpm build` — all packages tsup-build cleanly
- [ ] Smoke: install `ledric/laravel` against this branch, mount the GUI under `/ledric-admin/`, verify API calls and asset URLs route through the Laravel proxy
- [ ] Smoke: enable preview mode via inline-editor toggle, confirm draft content renders and toggle reflects state

🤖 Generated with [Claude Code](https://claude.com/claude-code)