### PR TITLE
fix(0.3.6): apply entryToWireShape to /rpc results

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ledric",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "ledric CLI — single-binary entry point.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -50,7 +50,7 @@ export const DEFAULTS: InitAnswers = {
 // Version pin for the @ledric/proxy dep we add to a consumer's
 // package.json. Kept in lockstep with the CLI's own version — bump on
 // each release that ships a proxy change.
-export const PROXY_DEP_VERSION = '^0.3.5';
+export const PROXY_DEP_VERSION = '^0.3.6';
 
 const LEDRIC_GITIGNORE_LINES: readonly string[] = [
   '# ledric',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/core",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "ledric core: schema engine, versioning, refs, validation, ACL. DB-agnostic.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/gui",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "ledric admin GUI — React via CDN, served by @ledric/http-server.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/http-server",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "ledric HTTP server: tool-shaped POST /rpc + REST GET projections, built on Fastify, binding @ledric/core.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/http-server/src/server.test.ts
+++ b/packages/http-server/src/server.test.ts
@@ -459,6 +459,78 @@ describe('HTTP server', () => {
     expect(body.statusCode).toBeUndefined();
     expect(body.message).toBeUndefined();
   });
+
+  // /rpc has historically returned the raw core result, leaking the
+  // legacy `content` field that MCP renames to `fields` at its tool
+  // boundary. These tests pin the rename so the two surfaces stay
+  // consistent.
+  it('POST /rpc { tool: read } returns fields (not content)', async () => {
+    await app.inject({
+      method: 'POST', url: '/rpc',
+      payload: { tool: 'create_type', args: {
+        name: 'post',
+        fields: { title: { type: 'string', required: true }, slug: { type: 'slug', from: 'title' } },
+        opts: { identifier_field: 'slug', display_field: 'title' }
+      }}
+    });
+    await app.inject({
+      method: 'POST', url: '/rpc',
+      payload: { tool: 'draft', args: { type: 'post', fields: { title: 'Hello' } } }
+    });
+    const res = await app.inject({
+      method: 'POST', url: '/rpc',
+      payload: { tool: 'read', args: { ref: { type: 'post', slug: 'hello' } } }
+    });
+    const body = JSON.parse(res.body);
+    expect(body.result).not.toBeNull();
+    expect(body.result.fields).toMatchObject({ title: 'Hello' });
+    expect(body.result.content).toBeUndefined();
+  });
+
+  it('POST /rpc { tool: find } projects fields on every result entry', async () => {
+    await app.inject({
+      method: 'POST', url: '/rpc',
+      payload: { tool: 'create_type', args: {
+        name: 'post',
+        fields: { title: { type: 'string', required: true }, slug: { type: 'slug', from: 'title' } },
+        opts: { identifier_field: 'slug', display_field: 'title' }
+      }}
+    });
+    for (const title of ['A', 'B']) {
+      await app.inject({
+        method: 'POST', url: '/rpc',
+        payload: { tool: 'draft', args: { type: 'post', fields: { title } } }
+      });
+    }
+    const res = await app.inject({
+      method: 'POST', url: '/rpc',
+      payload: { tool: 'find', args: { type: 'post' } }
+    });
+    const body = JSON.parse(res.body);
+    expect(body.result.results.length).toBe(2);
+    for (const entry of body.result.results) {
+      expect(entry.fields).toBeDefined();
+      expect(entry.content).toBeUndefined();
+    }
+  });
+
+  it('POST /rpc { tool: draft } returns the new entry with fields, not content', async () => {
+    await app.inject({
+      method: 'POST', url: '/rpc',
+      payload: { tool: 'create_type', args: {
+        name: 'post',
+        fields: { title: { type: 'string', required: true }, slug: { type: 'slug', from: 'title' } },
+        opts: { identifier_field: 'slug', display_field: 'title' }
+      }}
+    });
+    const res = await app.inject({
+      method: 'POST', url: '/rpc',
+      payload: { tool: 'draft', args: { type: 'post', fields: { title: 'Hi' } } }
+    });
+    const body = JSON.parse(res.body);
+    expect(body.result.fields).toMatchObject({ title: 'Hi' });
+    expect(body.result.content).toBeUndefined();
+  });
 });
 
 describe('HTTP server with GUI mount', () => {

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -18,7 +18,7 @@ const PKG_VERSION = (JSON.parse(
 ) as { version: string }).version;
 import type { Core } from '@ledric/core';
 import { parseTransformParams } from '@ledric/core';
-import { createStreamableHttpHandle } from '@ledric/mcp-server';
+import { createStreamableHttpHandle, entryToWireShape } from '@ledric/mcp-server';
 import type { StreamableHttpHandle } from '@ledric/mcp-server';
 import { SCOPE_TO_ROLE } from '@ledric/oauth';
 import type { Storage, ApiKeyRole, LedricStorage } from '@ledric/storage';
@@ -860,7 +860,11 @@ export function createHttpServer(core: Core, opts: HttpServerOptions = {}): Fast
     }
     try {
       const result = await dispatchTool(core, tool, args);
-      return { result: toJsonSafe(result) };
+      // Apply the same wire-shape rename (`content` → `fields`) MCP
+      // applies, so /rpc consumers get the documented envelope. Without
+      // this, `read`/`find`/`draft`/`publish` returned the legacy core
+      // shape and broke any client that targeted both surfaces.
+      return { result: toJsonSafe(applyWireShape(tool, result)) };
     } catch (err) {
       reply.code(400);
       return { error: { tool, ...serializeToolError(err) } };
@@ -1200,6 +1204,46 @@ async function dispatchTool(
     default:
       throw new Error(`Unknown tool "${tool}"`);
   }
+}
+
+/**
+ * Tools whose results contain entry shapes that need the wire-shape
+ * rename (`content` → `fields`). MCP applies this in the tool-handler
+ * layer; /rpc has historically returned the bare core result, which
+ * leaks the legacy `content` field and breaks consumers that target
+ * both surfaces.
+ */
+const ENTRY_RETURNING_TOOLS = new Set([
+  'read',
+  'draft',
+  'publish',
+  'rename_entry'
+]);
+
+const ENTRY_LIST_RETURNING_TOOLS = new Set(['find']);
+
+function applyWireShape(tool: string, result: unknown): unknown {
+  if (result === null || result === undefined) return result;
+
+  if (ENTRY_RETURNING_TOOLS.has(tool) && typeof result === 'object') {
+    return entryToWireShape(result as Record<string, unknown>);
+  }
+
+  if (ENTRY_LIST_RETURNING_TOOLS.has(tool) && typeof result === 'object') {
+    const obj = result as Record<string, unknown>;
+    if (Array.isArray(obj.results)) {
+      return {
+        ...obj,
+        results: obj.results.map((r) =>
+          r !== null && typeof r === 'object'
+            ? entryToWireShape(r as Record<string, unknown>)
+            : r
+        )
+      };
+    }
+  }
+
+  return result;
 }
 
 /**

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/mcp-server",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "ledric MCP server: MCP tool surface bound to @ledric/core (stdio + HTTP+SSE).",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -4,7 +4,8 @@ export {
   createMcpServer,
   SERVER_NAME,
   SERVER_VERSION,
-  SERVER_INSTRUCTIONS
+  SERVER_INSTRUCTIONS,
+  entryToWireShape
 } from './server.js';
 export { runStdio } from './stdio.js';
 export { createStreamableHttpHandle } from './streamable-http.js';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1049,7 +1049,7 @@ function isJsonScalar(v: unknown): boolean {
  * (schema_version, content_hash, current_version) — those are useful
  * for agents introspecting versioning and content identity.
  */
-function entryToWireShape(entry: Record<string, unknown>): Record<string, unknown> {
+export function entryToWireShape(entry: Record<string, unknown>): Record<string, unknown> {
   if (!('content' in entry)) return entry;
   const { content, ...rest } = entry as Record<string, unknown> & {
     content?: unknown;

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/oauth",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "OAuth 2.1 provider for ledric — DCR + auth code + PKCE + JWT/JWKS, single-process, no external IdP. Mounted by @ledric/http-server when mcp.public is on.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/proxy",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Server-side proxy primitive for ledric — keeps the browser off the ledric origin and keys off the client. Framework-agnostic (Request) => Promise<Response> handlers.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/schema",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "ledric schema definition helpers: defineType, field.*, JSON emit, Zod codegen.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/sdk",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "ledric vanilla TypeScript read client SDK.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/storage",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "ledric storage: Kysely-based dialect adapters. SQLite (better-sqlite3) default; MySQL and Postgres also supported.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

\`/rpc\` was returning the raw core result, leaking the legacy \`content\` field that MCP renames to \`fields\` at its tool boundary. Anyone targeting both surfaces (or using one of the SDKs that target \`/rpc\` — e.g. [\`ledric/laravel\`](https://github.com/getledric/ledric-laravel)) got an envelope MCP-style consumers couldn't parse. Recurring-bug entry in CLAUDE.md called this out for new MCP tools — the same trap was sitting on \`/rpc\` already.

- Export \`entryToWireShape\` from \`@ledric/mcp-server\`.
- New \`applyWireShape(tool, result)\` helper near \`dispatchTool\` walks results for entry-returning tools (\`read\`, \`draft\`, \`publish\`, \`rename_entry\`) and entry-list tools (\`find\`), applying the rename.
- 3 regression tests in \`server.test.ts\` pin the rename for \`read\` / \`find\` / \`draft\`. The \`find\` test is the one that matters most — its \`results[]\` array was the spot most likely to drift again on a future tool addition.

## Found via

The Laravel package's first cut was tested with mocked Guzzle responses, so the wire-shape mismatch only surfaced when a user pointed it at a live ledric (issue surfaced in [getledric/ledric-laravel#main](https://github.com/getledric/ledric-laravel)). The Laravel side has its own commit fixing the consumer side; this PR fixes the server side so the consumer-side defensive rename becomes a backstop, not the primary mechanism.

## Test plan

- [x] \`pnpm exec vitest run\` — 442 passed (3 new in server.test.ts)
- [x] \`pnpm build\` — clean
- [ ] Smoke: hit \`/rpc { tool: read }\` against a freshly-built ledric, confirm \`fields\` (not \`content\`) on the response

## Versions

Lockstep bump 0.3.5 → 0.3.6 across all 9 packages + \`PROXY_DEP_VERSION\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)