### PR TITLE
fix(0.3.7): GUI suppresses key prompt in proxy mode

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ledric",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "ledric CLI — single-binary entry point.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -50,7 +50,7 @@ export const DEFAULTS: InitAnswers = {
 // Version pin for the @ledric/proxy dep we add to a consumer's
 // package.json. Kept in lockstep with the CLI's own version — bump on
 // each release that ships a proxy change.
-export const PROXY_DEP_VERSION = '^0.3.6';
+export const PROXY_DEP_VERSION = '^0.3.7';
 
 const LEDRIC_GITIGNORE_LINES: readonly string[] = [
   '# ledric',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/core",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "ledric core: schema engine, versioning, refs, validation, ACL. DB-agnostic.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/gui",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "ledric admin GUI — React via CDN, served by @ledric/http-server.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/gui/web/lib/api.js
+++ b/packages/gui/web/lib/api.js
@@ -6,11 +6,18 @@
 // injects `<script>window.LEDRIC_BASE_URL = "/ledric-admin"</script>`
 // into the index. fetch() resolves bare paths against current origin,
 // so a path-only base URL works for both inline-mode and proxy-mode.
+//
+// Proxy mode also handles auth — the proxy injects an admin Bearer
+// outbound and strips inbound Authorization headers. The GUI must NOT
+// prompt for a key (the proxy is doing the work) and must NOT send its
+// own Authorization (it would be stripped anyway). PROXIED gates both.
 
-const ROOT =
-  typeof window !== 'undefined' && typeof window.LEDRIC_BASE_URL === 'string'
-    ? window.LEDRIC_BASE_URL.replace(/\/+$/, '')
-    : window.location.origin;
+const PROXIED =
+  typeof window !== 'undefined' && typeof window.LEDRIC_BASE_URL === 'string';
+
+const ROOT = PROXIED
+  ? window.LEDRIC_BASE_URL.replace(/\/+$/, '')
+  : window.location.origin;
 
 // localStorage key the admin paste-prompt writes to. Same origin as
 // the API, so the inline-editor iframe and the /admin SPA share it.
@@ -28,9 +35,12 @@ export const auth = {
   },
   /**
    * Hit the public /auth/status probe so callers can decide whether to
-   * show a key prompt without burning a 401.
+   * show a key prompt without burning a 401. In proxy mode the
+   * upstream proxy is handling auth on our behalf, so we lie to the
+   * AuthGate: no client-side key needed.
    */
   async status() {
+    if (PROXIED) return { required: false, reads_open: true };
     try {
       const res = await fetch(`${ROOT}/auth/status`);
       if (!res.ok) return { required: false, reads_open: true };
@@ -55,6 +65,9 @@ function fireUnauthorized() {
 }
 
 function authHeaders() {
+  // In proxy mode the proxy injects the Bearer; whatever we'd send
+  // here gets stripped by `scrubInboundHeaders` upstream anyway.
+  if (PROXIED) return {};
   const k = auth.key;
   return k ? { Authorization: `Bearer ${k}` } : {};
 }

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/http-server",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "ledric HTTP server: tool-shaped POST /rpc + REST GET projections, built on Fastify, binding @ledric/core.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/mcp-server",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "ledric MCP server: MCP tool surface bound to @ledric/core (stdio + HTTP+SSE).",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/oauth",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "OAuth 2.1 provider for ledric — DCR + auth code + PKCE + JWT/JWKS, single-process, no external IdP. Mounted by @ledric/http-server when mcp.public is on.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/proxy",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Server-side proxy primitive for ledric — keeps the browser off the ledric origin and keys off the client. Framework-agnostic (Request) => Promise<Response> handlers.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/schema",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "ledric schema definition helpers: defineType, field.*, JSON emit, Zod codegen.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/sdk",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "ledric vanilla TypeScript read client SDK.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/storage",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "ledric storage: Kysely-based dialect adapters. SQLite (better-sqlite3) default; MySQL and Postgres also supported.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

When the GUI is reached through a reverse proxy that injects an admin Bearer (e.g. \`ledric/laravel\`), the AuthGate still hit \`/auth/status\`, saw \`required: true\`, and prompted the user for a key — even though the proxy was already authenticating every request. Pasting a key didn't help: the proxy's \`scrubInboundHeaders\` strips inbound Authorization before forwarding upstream, so the user-typed key never reached ledric anyway.

## Fix

\`api.js\` gates two things on a single \`PROXIED\` constant — set when \`window.LEDRIC_BASE_URL\` is present, which the upstream injector adds whenever \`X-Forwarded-Prefix\` is on the request:

- \`auth.status()\` short-circuits to \`{required: false, reads_open: true}\`. AuthGate proceeds to render children.
- \`authHeaders()\` returns \`{}\` so we don't bother sending a header that's about to be stripped.

Inline mode (no proxy) is unchanged — both probes still go to ledric and the standard prompt-for-key flow runs.

## Test plan

- [x] \`pnpm build\` clean
- [x] \`pnpm exec vitest run\` — 442 tests pass
- [ ] Smoke: load the inline editor through the Laravel proxy and confirm no key prompt appears
- [ ] Smoke: \`ledric serve --gui\` directly (no proxy) still prompts when keys are configured

## Versions

Lockstep 0.3.6 → 0.3.7 + \`PROXY_DEP_VERSION\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)