### PR TITLE
fix(0.3.8): inline drawer save-draft + prose-invert in light mode

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ledric",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "ledric CLI — single-binary entry point.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -50,7 +50,7 @@ export const DEFAULTS: InitAnswers = {
 // Version pin for the @ledric/proxy dep we add to a consumer's
 // package.json. Kept in lockstep with the CLI's own version — bump on
 // each release that ships a proxy change.
-export const PROXY_DEP_VERSION = '^0.3.7';
+export const PROXY_DEP_VERSION = '^0.3.8';
 
 const LEDRIC_GITIGNORE_LINES: readonly string[] = [
   '# ledric',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/core",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "ledric core: schema engine, versioning, refs, validation, ACL. DB-agnostic.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/gui",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "ledric admin GUI — React via CDN, served by @ledric/http-server.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/gui/web/components/InlineDrawer.js
+++ b/packages/gui/web/components/InlineDrawer.js
@@ -102,7 +102,14 @@ export function InlineDrawer() {
     postToParent({ type: 'ledric:close' });
   }
 
-  async function save() {
+  // Two save modes — mirrors the full-page editor's split:
+  //   - saveDraft(): just `draft`. Leaves the live published version
+  //     alone; the editor closes and the consumer site keeps showing
+  //     the previously-published copy. Useful when reviewing in
+  //     preview mode without affecting visitors.
+  //   - savePublish(): `draft` then `publish`. The published_version
+  //     advances to the new draft so visitors see the change.
+  async function persist({ publish }) {
     if (!typeDef || saving) return;
     setSaving(true);
     setError(null);
@@ -113,16 +120,23 @@ export function InlineDrawer() {
         ref: { type, slug },
         parent_version: parentVersion
       });
-      // Publish what we just drafted. If validation fails here, the
-      // draft is left in place — same behaviour as the full /admin
-      // editor, and on retry the user's edits aren't lost.
-      const published = await api.rpc('publish', {
-        ref: { type, slug },
-        version: drafted.version
-      });
+      let published = null;
+      if (publish) {
+        // Publish what we just drafted. If validation fails here, the
+        // draft is left in place — same behaviour as the full /admin
+        // editor, and on retry the user's edits aren't lost.
+        published = await api.rpc('publish', {
+          ref: { type, slug },
+          version: drafted.version
+        });
+        setPublishedVersion(published.published_version);
+      }
       setParentVersion(drafted.version);
-      setPublishedVersion(published.published_version);
-      postToParent({ type: 'ledric:saved', version: published.published_version });
+      postToParent({
+        type: 'ledric:saved',
+        version: published ? published.published_version : drafted.version,
+        published: Boolean(published)
+      });
     } catch (e) {
       setError(e);
       // Refresh parent_version so a retry has a chance — covers the
@@ -137,6 +151,9 @@ export function InlineDrawer() {
       setSaving(false);
     }
   }
+
+  const saveDraft   = () => persist({ publish: false });
+  const savePublish = () => persist({ publish: true });
 
   const headerTitle =
     typeDef && content[typeDef.display_field ?? 'title']
@@ -216,7 +233,13 @@ export function InlineDrawer() {
             >cancel</button>
             <button
               type="button"
-              onClick=${save}
+              onClick=${saveDraft}
+              disabled=${saving}
+              className="border border-zinc-300 disabled:bg-zinc-100 disabled:text-zinc-400 text-zinc-700 hover:bg-zinc-100 transition px-3 py-1.5 rounded text-sm font-medium"
+            >${saving ? '…' : 'save draft'}</button>
+            <button
+              type="button"
+              onClick=${savePublish}
               disabled=${saving}
               className="bg-amber-500 disabled:bg-zinc-300 disabled:text-zinc-500 text-zinc-950 hover:bg-amber-400 transition px-4 py-1.5 rounded text-sm font-medium"
             >${saving ? 'saving…' : 'save & publish'}</button>

--- a/packages/gui/web/components/fields.js
+++ b/packages/gui/web/components/fields.js
@@ -293,7 +293,7 @@ function MarkdownField({ name, def, value, onChange }) {
         `}
         ${tab === 'preview' && html`
           <div
-            className="prose prose-invert prose-sm max-w-none px-4 py-3 min-h-[12rem] bg-zinc-50"
+            className="prose prose-sm max-w-none px-4 py-3 min-h-[12rem] bg-zinc-50"
             dangerouslySetInnerHTML=${{ __html: previewHtml || '<p class="text-zinc-400">empty</p>' }}
           />
         `}

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/http-server",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "ledric HTTP server: tool-shaped POST /rpc + REST GET projections, built on Fastify, binding @ledric/core.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/mcp-server",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "ledric MCP server: MCP tool surface bound to @ledric/core (stdio + HTTP+SSE).",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/oauth",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "OAuth 2.1 provider for ledric — DCR + auth code + PKCE + JWT/JWKS, single-process, no external IdP. Mounted by @ledric/http-server when mcp.public is on.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/proxy",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Server-side proxy primitive for ledric — keeps the browser off the ledric origin and keys off the client. Framework-agnostic (Request) => Promise<Response> handlers.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/schema",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "ledric schema definition helpers: defineType, field.*, JSON emit, Zod codegen.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/sdk",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "ledric vanilla TypeScript read client SDK.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledric/storage",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "ledric storage: Kysely-based dialect adapters. SQLite (better-sqlite3) default; MySQL and Postgres also supported.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

Two small GUI fixes surfaced when actually using the inline editor in production via the Laravel proxy.

### \`InlineDrawer\` save-draft button

The drawer only had \`save & publish\`, which forced every inline edit to go live immediately. Now mirrors the full-page editor's split:

- **save draft** — runs \`draft\` only. Useful in preview mode to stage changes without affecting visitors.
- **save & publish** — runs \`draft\` then \`publish\`, same as before.

postMessage payload to \`inline.js\` now carries \`published: bool\` alongside \`version\` for the listener.

### Markdown preview prose colors

\`fields.js\` was using \`prose prose-invert prose-sm\` for the markdown preview pane. \`prose-invert\` is a holdover from the original dark theme — under the light theme the inverted variables resolve to white headings (\`--tw-prose-headings: white\`) on a near-white \`bg-zinc-50\` background, so titles were invisible. Dropping \`prose-invert\` restores correct contrast.

## Test plan

- [x] \`pnpm build\` clean
- [x] \`pnpm exec vitest run\` — 442 passed
- [ ] Smoke: open inline editor on a non-preview page, save draft, confirm the published version is unchanged
- [ ] Smoke: same flow with preview mode on, confirm draft renders after reload
- [ ] Smoke: a markdown body with \`# heading\` previews with visible black title text on the light background

## Versions

Lockstep 0.3.7 → 0.3.8 + \`PROXY_DEP_VERSION\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)